### PR TITLE
Calibnet config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,3 +21,7 @@ indent_size = 2
 
 # Disable trimming trailing whitespace for Go files, as it may affect raw string literals
 trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+trim_trailing_whitespace = true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ SHELL=/bin/bash -o pipefail
 all: glif
 
 glif: main.go
-	go build -o glif .
+	go build $(GOFLAGS) -o glif .
+.PHONY: glif
 
 clean:
 	rm -f glif
@@ -13,8 +14,11 @@ config:
 	cp config.toml ~/.glif/config.toml
 
 calibnet-config:
-	mkdir -p ~/.glif
-	cp calibnet-config.toml ~/.glif/config.toml
+	mkdir -p ~/.glif/calibnet
+	cp calibnet-config.toml ~/.glif/calibnet/config.toml
+
+calibnet: GOFLAGS+=-tags=calibnet
+calibnet: glif
 
 install: glif
 	cp glif /usr/local/bin/glif

--- a/cmd/agent_miners_change_worker.go
+++ b/cmd/agent_miners_change_worker.go
@@ -15,7 +15,7 @@ import (
 
 // changeWorkerCmd represents the changeWorker command
 var changeWorkerCmd = &cobra.Command{
-	Use:   "change-worker",
+	Use:   "change-worker <miner address> <worker address> [control addresses...]",
 	Short: "Change the worker address of your miner",
 	Long:  ``,
 	Args:  cobra.RangeArgs(2, 5),
@@ -25,20 +25,24 @@ var changeWorkerCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		minerAddr, err := address.NewFromString(args[0])
+		minerAddr, err := ToMinerID(cmd.Context(), args[0])
 		if err != nil {
 			log.Fatal(err)
 		}
+		log.Println(minerAddr)
 
-		workerAddr, err := address.NewFromString(args[1])
+		workerAddr, err := ToMinerID(cmd.Context(), args[1])
 		if err != nil {
+			log.Print("Error parsing worker address")
 			log.Fatal(err)
 		}
+		log.Println(workerAddr)
 
 		var controlAddrs []address.Address
 		for _, arg := range args[2:] {
-			controlAddr, err := address.NewFromString(arg)
+			controlAddr, err := ToMinerID(cmd.Context(), arg)
 			if err != nil {
+				log.Print("Error parsing control address")
 				log.Fatal(err)
 			}
 			controlAddrs = append(controlAddrs, controlAddr)
@@ -51,7 +55,7 @@ var changeWorkerCmd = &cobra.Command{
 
 		tx, err := PoolsSDK.Act().AgentChangeMinerWorker(cmd.Context(), agentAddr, minerAddr, workerAddr, controlAddrs, ownerKey)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatalf("tx error: %s", err)
 		}
 
 		// transaction landed on chain or errored
@@ -62,7 +66,7 @@ var changeWorkerCmd = &cobra.Command{
 
 		s.Stop()
 
-		fmt.Println("Successfully changed miner worker - you must confirm this change yourself using `glif agent miners confirm-worker-change`")
+		fmt.Println("Successfully changed miner worker - you must confirm this change yourself using `glif agent miners confirm-worker`")
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,15 +30,13 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
 var cfgDir string
+var useCalibnet bool // only set in root_calibnet.go
 var PoolsSDK types.PoolsSDK
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "glif",
-	Short: "",
-	Long:  ``,
+	Use: "glif",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -52,9 +50,8 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&cfgDir, "config-dir", "", "config directory (default is $HOME/.glif/)")
+	rootCmd.PersistentFlags().StringVar(&cfgDir, "config-dir", "", "config directory")
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -69,9 +66,12 @@ func initConfig() {
 		cobra.CheckErr(err)
 
 		cfgDir = fmt.Sprintf("%s/.glif", home)
+		if useCalibnet {
+			cfgDir = fmt.Sprintf("%s/.glif/%s", home, "calibnet")
+		}
 
 		// Search config in home directory with name ".glif" (without extension).
-		viper.AddConfigPath(fmt.Sprintf("%s/.glif", home))
+		viper.AddConfigPath(cfgDir)
 		viper.AddConfigPath(".")
 	}
 

--- a/cmd/root_calibnet.go
+++ b/cmd/root_calibnet.go
@@ -1,0 +1,23 @@
+//go:build calibnet
+// +build calibnet
+
+/*
+Copyright © 2023 Glif LTD
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+func init() {
+	rootCmd.PersistentFlags().BoolVar(&useCalibnet, "calibnet", true, "use calibnet")
+}


### PR DESCRIPTION
make use of go build tags to create a separate directory and cfgDir value for calibnet, similar to how lotus does build values for calibnet