### PR TITLE
Feat/preview flags

### DIFF
--- a/cmd/agent_miners_add.go
+++ b/cmd/agent_miners_add.go
@@ -11,8 +11,11 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/filecoin-project/go-address"
 	"github.com/glifio/cli/events"
+	"github.com/glifio/go-pools/constants"
 	"github.com/spf13/cobra"
 )
+
+var addPreview bool
 
 // addCmd represents the add command
 var addCmd = &cobra.Command{
@@ -21,6 +24,10 @@ var addCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if addPreview {
+			previewAction(cmd, args, constants.MethodAddMiner)
+			return
+		}
 		agentAddr, ownerKey, requesterKey, err := commonSetupOwnerCall()
 		if err != nil {
 			logFatal(err)
@@ -67,4 +74,5 @@ var addCmd = &cobra.Command{
 
 func init() {
 	minersCmd.AddCommand(addCmd)
+	addCmd.Flags().BoolVar(&addPreview, "preview", false, "preview the financial outcome of an add miner action")
 }

--- a/cmd/agent_miners_remove.go
+++ b/cmd/agent_miners_remove.go
@@ -10,8 +10,11 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/filecoin-project/go-address"
 	"github.com/glifio/cli/events"
+	"github.com/glifio/go-pools/constants"
 	"github.com/spf13/cobra"
 )
+
+var removePreview bool
 
 // addCmd represents the add command
 var rmCmd = &cobra.Command{
@@ -21,6 +24,11 @@ var rmCmd = &cobra.Command{
 	The new owner address must be a filecoin address, not a delegated address.`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
+		if removePreview {
+			previewAction(cmd, args, constants.MethodRemoveMiner)
+			return
+		}
+
 		agentAddr, ownerKey, requesterKey, err := commonSetupOwnerCall()
 		if err != nil {
 			logFatal(err)
@@ -77,4 +85,5 @@ var rmCmd = &cobra.Command{
 
 func init() {
 	minersCmd.AddCommand(rmCmd)
+	rmCmd.Flags().BoolVar(&removePreview, "preview", false, "preview the financial outcome of a remove miner action")
 }

--- a/cmd/agent_pay_current.go
+++ b/cmd/agent_pay_current.go
@@ -6,20 +6,39 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/glifio/go-pools/constants"
 	"github.com/glifio/go-pools/util"
 	"github.com/spf13/cobra"
 )
+
+var payToCurrentPreview bool
 
 var payToCurrentCmd = &cobra.Command{
 	Use:   "to-current [flags]",
 	Short: "Make your account current",
 	Long:  "Pays off all fees owed",
 	Run: func(cmd *cobra.Command, args []string) {
+		if payToCurrentPreview {
+			agentAddr, err := getAgentAddress(cmd)
+			if err != nil {
+				logFatal(err)
+			}
+
+			amountOwed, _, err := PoolsSDK.Query().AgentOwes(cmd.Context(), agentAddr)
+			if err != nil {
+				logFatal(err)
+			}
+
+			args = append(args, util.ToFIL(amountOwed).String())
+			previewAction(cmd, args, constants.MethodPay)
+			return
+		}
+
 		payAmt, err := pay(cmd, args, ToCurrent, false)
 		if err != nil {
 			logFatal(err)
 		}
-		fmt.Printf("Successfully paid %s FIL", util.ToFIL(payAmt).String())
+		fmt.Printf("Successfully paid %s FIL\n", util.ToFIL(payAmt).String())
 	},
 }
 
@@ -27,4 +46,5 @@ func init() {
 	payCmd.AddCommand(payToCurrentCmd)
 	payToCurrentCmd.Flags().String("pool-name", "infinity-pool", "name of the pool to make a payment")
 	payToCurrentCmd.Flags().String("from", "", "address to send the transaction from")
+	payToCurrentCmd.Flags().BoolVar(&payToCurrentPreview, "preview", false, "preview financial outcome of pay to-current action")
 }

--- a/cmd/agent_pay_custom.go
+++ b/cmd/agent_pay_custom.go
@@ -6,9 +6,12 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/glifio/go-pools/constants"
 	"github.com/glifio/go-pools/util"
 	"github.com/spf13/cobra"
 )
+
+var payCustomPreview bool
 
 var payCustomCmd = &cobra.Command{
 	Use:   "custom <amount> [flags]",
@@ -16,6 +19,10 @@ var payCustomCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {
+		if payCustomPreview {
+			previewAction(cmd, args, constants.MethodPay)
+			return
+		}
 		payAmt, err := pay(cmd, args, Custom, false)
 		if err != nil {
 			logFatal(err)
@@ -28,4 +35,5 @@ func init() {
 	payCmd.AddCommand(payCustomCmd)
 	payCustomCmd.Flags().String("pool-name", "infinity-pool", "name of the pool to make a payment")
 	payCustomCmd.Flags().String("from", "", "address to send the transaction from")
+	payCustomCmd.Flags().BoolVar(&payCustomPreview, "preview", false, "preview financial outcome of pay custom action")
 }

--- a/cmd/agent_pay_principal.go
+++ b/cmd/agent_pay_principal.go
@@ -5,10 +5,14 @@ package cmd
 
 import (
 	"fmt"
+	"math/big"
 
+	"github.com/glifio/go-pools/constants"
 	"github.com/glifio/go-pools/util"
 	"github.com/spf13/cobra"
 )
+
+var payPrincipalPreview bool
 
 var payPrincipalCmd = &cobra.Command{
 	Use:   "principal <amount> [flags]",
@@ -16,12 +20,32 @@ var payPrincipalCmd = &cobra.Command{
 	Long:  "<amount> is the amount of principal to pay down, in FIL. Any fees owed will be paid off as well in order to make the principal payment",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if payPrincipalPreview {
+			agentAddr, err := getAgentAddress(cmd)
+			if err != nil {
+				logFatal(err)
+			}
+			amount, err := parseFILAmount(args[0])
+			if err != nil {
+				logFatal(err)
+			}
+
+			amountOwed, _, err := PoolsSDK.Query().AgentOwes(cmd.Context(), agentAddr)
+			if err != nil {
+				logFatal(err)
+			}
+
+			payAmt := new(big.Int).Add(amount, amountOwed)
+			args = append(args, util.ToFIL(payAmt).String())
+			previewAction(cmd, args, constants.MethodPay)
+			return
+		}
 		payAmt, err := pay(cmd, args, Principal, false)
 		if err != nil {
 			logFatal(err)
 		}
 
-		fmt.Printf("Successfully paid %s FIL", util.ToFIL(payAmt).String())
+		fmt.Printf("Successfully paid %s FIL\n", util.ToFIL(payAmt).String())
 	},
 }
 
@@ -29,4 +53,5 @@ func init() {
 	payCmd.AddCommand(payPrincipalCmd)
 	payPrincipalCmd.Flags().String("pool-name", "infinity-pool", "name of the pool to make a payment")
 	payPrincipalCmd.Flags().String("from", "", "address to send the transaction from")
+	payPrincipalCmd.Flags().BoolVar(&payPrincipalPreview, "preview", false, "preview financial outcome of pay principal action")
 }

--- a/cmd/agent_preview.go
+++ b/cmd/agent_preview.go
@@ -90,5 +90,5 @@ func previewAction(cmd *cobra.Command, args []string, action constants.Method) {
 	fmt.Printf("Total borrowed before/after: %0.09f => %0.09f\n", util.ToFIL(agentDataBefore.Principal), util.ToFIL(agentDataAfter.Principal))
 	fmt.Printf("GCRED before/after: %s => %s\n", agentDataBefore.Gcred, agentDataAfter.Gcred)
 	fmt.Printf("The weekly/annual fee rate: %.03f%% / %.03f%%\n", wprFloat*100, aprFloat*100)
-	fmt.Printf("Your weekly min payment will be: %.06f FIL", weeklyPmt)
+	fmt.Printf("Your weekly min payment will be: %.06f FIL\n", weeklyPmt)
 }

--- a/cmd/agent_preview_borrow.go
+++ b/cmd/agent_preview_borrow.go
@@ -66,7 +66,7 @@ var previewBorrowCmd = &cobra.Command{
 		fmt.Printf("Total borrowed before/after: %0.09f => %0.09f\n", util.ToFIL(agentDataBefore.Principal), util.ToFIL(agentDataAfter.Principal))
 		fmt.Printf("GCRED before/after: %s => %s\n", agentDataBefore.Gcred, agentDataAfter.Gcred)
 		fmt.Printf("The weekly/annual fee rate: %.03f%% / %.03f%%\n", wprFloat*100, aprFloat*100)
-		fmt.Printf("Your weekly min payment will be: %.06f FIL", weeklyPmt)
+		fmt.Printf("Your weekly min payment will be: %.06f FIL\n", weeklyPmt)
 	},
 }
 

--- a/cmd/agent_withdraw.go
+++ b/cmd/agent_withdraw.go
@@ -10,8 +10,11 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/glifio/cli/events"
+	"github.com/glifio/go-pools/constants"
 	"github.com/spf13/cobra"
 )
+
+var withdrawPreview bool
 
 // borrowCmd represents the borrow command
 var withdrawCmd = &cobra.Command{
@@ -20,6 +23,11 @@ var withdrawCmd = &cobra.Command{
 	Long:  "",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if withdrawPreview {
+			previewAction(cmd, args, constants.MethodWithdraw)
+			return
+		}
+
 		agentAddr, ownerKey, requesterKey, err := commonSetupOwnerCall()
 		if err != nil {
 			logFatal(err)
@@ -75,4 +83,5 @@ var withdrawCmd = &cobra.Command{
 
 func init() {
 	agentCmd.AddCommand(withdrawCmd)
+	withdrawCmd.Flags().BoolVar(&withdrawPreview, "preview", false, "preview the financial outcome of a withdraw action")
 }


### PR DESCRIPTION
builds off #78 and adds preview flags to `pay *`, `withdraw`, `add` and `rm` miner cmds.

This requires an ADO PR to be merged first.