### PR TITLE
Fix exit with status code

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ import (
 )
 
 func main() {
-	defer os.Exit(cmd.ExitCode)
+	defer func() {
+		os.Exit(cmd.ExitCode)
+	}()
 	cmd.Execute()
 }


### PR DESCRIPTION
The cli process wasn't exiting with a non-zero status code when exiting after an error.