### PR TITLE
Schwartz cmds

### DIFF
--- a/cmd/agent_admin.go
+++ b/cmd/agent_admin.go
@@ -1,0 +1,17 @@
+/*
+Copyright © 2023 Glif LTD
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var adminCmd = &cobra.Command{
+	Use:   "admin",
+	Short: "Commands for controlling the Agent's ownership and health status",
+}
+
+func init() {
+	agentCmd.AddCommand(adminCmd)
+}

--- a/cmd/agent_admin_accept_operator.go
+++ b/cmd/agent_admin_accept_operator.go
@@ -1,0 +1,61 @@
+/*
+Copyright © 2023 Glif LTD
+*/
+package cmd
+
+import (
+	"log"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/glifio/cli/events"
+	"github.com/spf13/cobra"
+)
+
+var acceptOperatorCmd = &cobra.Command{
+	Use:   "accept-operator",
+	Short: "Approves an operator change on the Agent",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
+		agentAddr, auth, _, _, err := commonSetupOwnerCall()
+		if err != nil {
+			logFatal(err)
+		}
+
+		s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		s.Start()
+		defer s.Stop()
+
+		exitevt := journal.RegisterEventType("agent", "admin")
+		evt := &events.AgentAdmin{
+			Action:  "accept-operator",
+			AgentID: agentAddr.String(),
+		}
+		defer journal.Close()
+		defer journal.RecordEvent(exitevt, func() interface{} { return evt })
+
+		tx, err := PoolsSDK.Act().AgentAcceptOperator(ctx, auth, agentAddr)
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+		evt.Tx = tx.Hash().String()
+
+		// transaction landed on chain or errored
+		_, err = PoolsSDK.Query().StateWaitReceipt(ctx, tx.Hash())
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+
+		s.Stop()
+
+		log.Printf("Successfully accepted operator change on agent %s\n", agentAddr.String())
+	},
+}
+
+func init() {
+	adminCmd.AddCommand(acceptOperatorCmd)
+}

--- a/cmd/agent_admin_accept_ownership.go
+++ b/cmd/agent_admin_accept_ownership.go
@@ -1,0 +1,61 @@
+/*
+Copyright © 2023 Glif LTD
+*/
+package cmd
+
+import (
+	"log"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/glifio/cli/events"
+	"github.com/spf13/cobra"
+)
+
+var acceptOwnershipCmd = &cobra.Command{
+	Use:   "accept-ownership",
+	Short: "Approves an ownership change on the Agent",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
+		agentAddr, auth, _, _, err := commonSetupOwnerCall()
+		if err != nil {
+			logFatal(err)
+		}
+
+		s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		s.Start()
+		defer s.Stop()
+
+		exitevt := journal.RegisterEventType("agent", "admin")
+		evt := &events.AgentAdmin{
+			Action:  "accept-ownership",
+			AgentID: agentAddr.String(),
+		}
+		defer journal.Close()
+		defer journal.RecordEvent(exitevt, func() interface{} { return evt })
+
+		tx, err := PoolsSDK.Act().AgentAcceptOwnership(ctx, auth, agentAddr)
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+		evt.Tx = tx.Hash().String()
+
+		// transaction landed on chain or errored
+		_, err = PoolsSDK.Query().StateWaitReceipt(ctx, tx.Hash())
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+
+		s.Stop()
+
+		log.Printf("Successfully accepted ownership change on agent %s\n", agentAddr.String())
+	},
+}
+
+func init() {
+	adminCmd.AddCommand(acceptOwnershipCmd)
+}

--- a/cmd/agent_admin_change_requester.go
+++ b/cmd/agent_admin_change_requester.go
@@ -20,7 +20,7 @@ var changeRequesterCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 
-		newRequester, err := ParseAddressToEVM(ctx, args[0])
+		newRequester, err := AddressOrAccountNameToEVM(ctx, args[0])
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/agent_admin_change_requester.go
+++ b/cmd/agent_admin_change_requester.go
@@ -1,0 +1,68 @@
+/*
+Copyright © 2023 Glif LTD
+*/
+package cmd
+
+import (
+	"log"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/glifio/cli/events"
+	"github.com/spf13/cobra"
+)
+
+var changeRequesterCmd = &cobra.Command{
+	Use:   "change-requester <new-requester-addr>",
+	Short: "Changes the requester key on the Agent",
+	Long:  "The `ADORequesterKey` is the key that is used to sign requests to the Agent Data Oracle. This command changes the key that signs requests for Signed Credentials from the Oracle.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
+		newRequester, err := ParseAddressToEVM(ctx, args[0])
+		if err != nil {
+			logFatal(err)
+		}
+
+		agentAddr, auth, _, _, err := commonSetupOwnerCall()
+		if err != nil {
+			logFatal(err)
+		}
+
+		s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		s.Start()
+		defer s.Stop()
+
+		exitevt := journal.RegisterEventType("agent", "admin")
+		evt := &events.AgentAdmin{
+			Action:          "change-requester",
+			AgentID:         agentAddr.String(),
+			NewAdminAddress: newRequester.Hex(),
+		}
+		defer journal.Close()
+		defer journal.RecordEvent(exitevt, func() interface{} { return evt })
+
+		tx, err := PoolsSDK.Act().AgentChangeRequester(ctx, auth, agentAddr, newRequester)
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+		evt.Tx = tx.Hash().String()
+
+		// transaction landed on chain or errored
+		_, err = PoolsSDK.Query().StateWaitReceipt(ctx, tx.Hash())
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+
+		s.Stop()
+
+		log.Printf("Successfully changed requester key on the agent: %s, new requester: %s\n", agentAddr.String(), newRequester.Hex())
+	},
+}
+
+func init() {
+	adminCmd.AddCommand(changeRequesterCmd)
+}

--- a/cmd/agent_admin_set_recovered.go
+++ b/cmd/agent_admin_set_recovered.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2023 Glif LTD
+*/
+package cmd
+
+import (
+	"log"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/glifio/cli/events"
+	"github.com/spf13/cobra"
+)
+
+var setRecoveredCmd = &cobra.Command{
+	Use:   "set-recovered",
+	Short: "Sets the Agent back into good standing",
+	Long:  "If the Agent recovers from being in a faulty state, this command marks the Agent as healthy again.",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
+		agentAddr, auth, _, requesterKey, err := commonSetupOwnerCall()
+		if err != nil {
+			logFatal(err)
+		}
+
+		s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		s.Start()
+		defer s.Stop()
+
+		exitevt := journal.RegisterEventType("agent", "admin")
+		evt := &events.AgentAdmin{
+			Action:  "set-recovered",
+			AgentID: agentAddr.String(),
+		}
+		defer journal.Close()
+		defer journal.RecordEvent(exitevt, func() interface{} { return evt })
+
+		tx, err := PoolsSDK.Act().AgentSetRecovered(ctx, auth, agentAddr, requesterKey)
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+		evt.Tx = tx.Hash().String()
+
+		// transaction landed on chain or errored
+		_, err = PoolsSDK.Query().StateWaitReceipt(ctx, tx.Hash())
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+
+		s.Stop()
+
+		log.Println("Successfully recovered agent: ", agentAddr.String())
+	},
+}
+
+func init() {
+	adminCmd.AddCommand(setRecoveredCmd)
+}

--- a/cmd/agent_admin_transfer_operator.go
+++ b/cmd/agent_admin_transfer_operator.go
@@ -19,7 +19,7 @@ var transferOperatorCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 
-		newOperator, err := ParseAddressToEVM(ctx, args[0])
+		newOperator, err := AddressOrAccountNameToEVM(ctx, args[0])
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/agent_admin_transfer_operator.go
+++ b/cmd/agent_admin_transfer_operator.go
@@ -1,0 +1,67 @@
+/*
+Copyright © 2023 Glif LTD
+*/
+package cmd
+
+import (
+	"log"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/glifio/cli/events"
+	"github.com/spf13/cobra"
+)
+
+var transferOperatorCmd = &cobra.Command{
+	Use:   "transfer-operator <new-operator>",
+	Short: "Proposes an operator change to the Agent",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
+		newOperator, err := ParseAddressToEVM(ctx, args[0])
+		if err != nil {
+			logFatal(err)
+		}
+
+		agentAddr, auth, _, _, err := commonSetupOwnerCall()
+		if err != nil {
+			logFatal(err)
+		}
+
+		s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		s.Start()
+		defer s.Stop()
+
+		exitevt := journal.RegisterEventType("agent", "admin")
+		evt := &events.AgentAdmin{
+			Action:          "transfer-operator",
+			AgentID:         agentAddr.String(),
+			NewAdminAddress: newOperator.Hex(),
+		}
+		defer journal.Close()
+		defer journal.RecordEvent(exitevt, func() interface{} { return evt })
+
+		tx, err := PoolsSDK.Act().AgentTransferOperator(ctx, auth, agentAddr, newOperator)
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+		evt.Tx = tx.Hash().String()
+
+		// transaction landed on chain or errored
+		_, err = PoolsSDK.Query().StateWaitReceipt(ctx, tx.Hash())
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+
+		s.Stop()
+
+		log.Printf("Successfully proposed operator change to agent %s, new operator %s\n", agentAddr.String(), newOperator.Hex())
+	},
+}
+
+func init() {
+	adminCmd.AddCommand(transferOperatorCmd)
+}

--- a/cmd/agent_admin_transfer_ownership.go
+++ b/cmd/agent_admin_transfer_ownership.go
@@ -19,7 +19,7 @@ var transferOwnershipCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 
-		newOwner, err := ParseAddressToEVM(ctx, args[0])
+		newOwner, err := AddressOrAccountNameToEVM(ctx, args[0])
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/agent_admin_transfer_ownership.go
+++ b/cmd/agent_admin_transfer_ownership.go
@@ -1,0 +1,67 @@
+/*
+Copyright © 2023 Glif LTD
+*/
+package cmd
+
+import (
+	"log"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/glifio/cli/events"
+	"github.com/spf13/cobra"
+)
+
+var transferOwnershipCmd = &cobra.Command{
+	Use:   "transfer-ownership <new-owner>",
+	Short: "Proposes an ownership change to the Agent",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
+		newOwner, err := ParseAddressToEVM(ctx, args[0])
+		if err != nil {
+			logFatal(err)
+		}
+
+		agentAddr, auth, _, _, err := commonSetupOwnerCall()
+		if err != nil {
+			logFatal(err)
+		}
+
+		s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		s.Start()
+		defer s.Stop()
+
+		exitevt := journal.RegisterEventType("agent", "admin")
+		evt := &events.AgentAdmin{
+			Action:          "transfer-ownership",
+			AgentID:         agentAddr.String(),
+			NewAdminAddress: newOwner.Hex(),
+		}
+		defer journal.Close()
+		defer journal.RecordEvent(exitevt, func() interface{} { return evt })
+
+		tx, err := PoolsSDK.Act().AgentTransferOwnership(ctx, auth, agentAddr, newOwner)
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+		evt.Tx = tx.Hash().String()
+
+		// transaction landed on chain or errored
+		_, err = PoolsSDK.Query().StateWaitReceipt(ctx, tx.Hash())
+		if err != nil {
+			evt.Error = err.Error()
+			logFatal(err)
+		}
+
+		s.Stop()
+
+		log.Printf("Successfully proposed ownership change to agent %s, new owner %s\n", agentAddr.String(), newOwner.Hex())
+	},
+}
+
+func init() {
+	adminCmd.AddCommand(transferOwnershipCmd)
+}

--- a/cmd/agent_create.go
+++ b/cmd/agent_create.go
@@ -23,7 +23,7 @@ var createCmd = &cobra.Command{
 	Short: "Create a Glif agent",
 	Long:  `Spins up a new Agent contract through the Agent Factory, passing the owner, operator, and requestor addresses.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		as := util.AgentStore()
+		as := util.AccountsStore()
 		ks := util.KeyStore()
 		backends := []accounts.Backend{}
 		backends = append(backends, ks)

--- a/cmd/agent_create.go
+++ b/cmd/agent_create.go
@@ -39,18 +39,27 @@ var createCmd = &cobra.Command{
 			logFatalf("Agent already exists: %s", addressStr)
 		}
 
-		ownerAddr, _, err := as.GetAddrs(util.OwnerKey)
+		ownerAddr, _, err := as.GetAddrs(string(util.OwnerKey))
 		if err != nil {
+			if err.Error() == "not found" {
+				logFatal("Agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
+			}
 			logFatal(err)
 		}
 
-		operatorAddr, _, err := as.GetAddrs(util.OperatorKey)
+		operatorAddr, _, err := as.GetAddrs(string(util.OperatorKey))
 		if err != nil {
+			if err.Error() == "not found" {
+				logFatal("Agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
+			}
 			logFatal(err)
 		}
 
-		requestAddr, _, err := as.GetAddrs(util.RequestKey)
+		requestAddr, _, err := as.GetAddrs(string(util.RequestKey))
 		if err != nil {
+			if err.Error() == "not found" {
+				logFatal("Agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
+			}
 			logFatal(err)
 		}
 

--- a/cmd/agent_create.go
+++ b/cmd/agent_create.go
@@ -24,6 +24,7 @@ var createCmd = &cobra.Command{
 	Long:  `Spins up a new Agent contract through the Agent Factory, passing the owner, operator, and requestor addresses.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		as := util.AccountsStore()
+		agentStore := util.AgentStore()
 		ks := util.KeyStore()
 		backends := []accounts.Backend{}
 		backends = append(backends, ks)
@@ -116,9 +117,9 @@ var createCmd = &cobra.Command{
 		fmt.Printf("Agent created: %s\n", addr.String())
 		fmt.Printf("Agent ID: %s\n", id.String())
 
-		as.Set("id", id.String())
-		as.Set("address", addr.String())
-		as.Set("tx", tx.Hash().String())
+		agentStore.Set("id", id.String())
+		agentStore.Set("address", addr.String())
+		agentStore.Set("tx", tx.Hash().String())
 	},
 }
 

--- a/cmd/agent_create.go
+++ b/cmd/agent_create.go
@@ -125,8 +125,4 @@ var createCmd = &cobra.Command{
 
 func init() {
 	agentCmd.AddCommand(createCmd)
-
-	createCmd.Flags().String("ownerfile", "", "Owner eth address")
-	createCmd.Flags().String("operatorfile", "", "Repayment eth address")
-	createCmd.Flags().String("deployerfile", "", "Deployer eth address")
 }

--- a/cmd/agent_create.go
+++ b/cmd/agent_create.go
@@ -40,28 +40,13 @@ var createCmd = &cobra.Command{
 		}
 
 		ownerAddr, _, err := as.GetAddrs(string(util.OwnerKey))
-		if err != nil {
-			if err.Error() == "not found" {
-				logFatal("Agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
-			}
-			logFatal(err)
-		}
+		checkExists(err)
 
 		operatorAddr, _, err := as.GetAddrs(string(util.OperatorKey))
-		if err != nil {
-			if err.Error() == "not found" {
-				logFatal("Agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
-			}
-			logFatal(err)
-		}
+		checkExists(err)
 
 		requestAddr, _, err := as.GetAddrs(string(util.RequestKey))
-		if err != nil {
-			if err.Error() == "not found" {
-				logFatal("Agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
-			}
-			logFatal(err)
-		}
+		checkExists(err)
 
 		account := accounts.Account{Address: ownerAddr}
 		passphrase, envSet := os.LookupEnv("GLIF_OWNER_PASSPHRASE")
@@ -130,6 +115,15 @@ var createCmd = &cobra.Command{
 		agentStore.Set("address", addr.String())
 		agentStore.Set("tx", tx.Hash().String())
 	},
+}
+
+func checkExists(err error) {
+	if err != nil {
+		if err == util.ErrKeyNotFound {
+			logFatal("Agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
+		}
+		logFatal(err)
+	}
 }
 
 func init() {

--- a/cmd/agent_withdraw.go
+++ b/cmd/agent_withdraw.go
@@ -23,7 +23,7 @@ var withdrawCmd = &cobra.Command{
 			logFatal(err)
 		}
 
-		receiver, err := ParseAddressToEVM(cmd.Context(), args[1])
+		receiver, err := AddressOrAccountNameToEVM(cmd.Context(), args[1])
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/ifil_approve.go
+++ b/cmd/ifil_approve.go
@@ -15,7 +15,7 @@ var iFILApproveCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		from := cmd.Flag("from").Value.String()
-		_, auth, _, _, err := commonOwnerOrOperatorSetup(ctx, from)
+		auth, _, err := commonGenericAccountSetup(ctx, from)
 		if err != nil {
 			logFatal(err)
 		}
@@ -56,5 +56,5 @@ var iFILApproveCmd = &cobra.Command{
 
 func init() {
 	iFILCmd.AddCommand(iFILApproveCmd)
-	iFILApproveCmd.Flags().String("from", "", "address of the owner or operator of the agent")
+	iFILApproveCmd.Flags().String("from", "default", "account to approve iFIL transfer from")
 }

--- a/cmd/ifil_approve.go
+++ b/cmd/ifil_approve.go
@@ -24,7 +24,7 @@ var iFILApproveCmd = &cobra.Command{
 		strAmt := args[1]
 		fmt.Printf("Approving %s to spend %s of your iFIL balance...\n", strAddr, strAmt)
 
-		addr, err := ParseAddressToEVM(ctx, strAddr)
+		addr, err := AddressOrAccountNameToEVM(ctx, strAddr)
 		if err != nil {
 			logFatalf("Failed to parse address %s", err)
 		}

--- a/cmd/ifil_balanceof.go
+++ b/cmd/ifil_balanceof.go
@@ -16,7 +16,7 @@ var iFILBalanceOfCmd = &cobra.Command{
 		strAddr := args[0]
 		fmt.Printf("Checking iFIL balance of %s...", strAddr)
 
-		addr, err := ParseAddressToEVM(cmd.Context(), strAddr)
+		addr, err := AddressOrAccountNameToEVM(cmd.Context(), strAddr)
 		if err != nil {
 			logFatalf("Failed to parse address %s", err)
 		}

--- a/cmd/ifil_transfer.go
+++ b/cmd/ifil_transfer.go
@@ -25,7 +25,7 @@ var iFILTransferCmd = &cobra.Command{
 		strAmt := args[1]
 		fmt.Printf("Transferring %s iFIL balance to %s...\n", strAmt, strAddr)
 
-		addr, err := ParseAddressToEVM(ctx, strAddr)
+		addr, err := AddressOrAccountNameToEVM(ctx, strAddr)
 		if err != nil {
 			logFatalf("Failed to parse address %s", err)
 		}

--- a/cmd/ifil_transfer.go
+++ b/cmd/ifil_transfer.go
@@ -16,7 +16,7 @@ var iFILTransferCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		from := cmd.Flag("from").Value.String()
-		_, auth, _, _, err := commonOwnerOrOperatorSetup(ctx, from)
+		auth, _, err := commonGenericAccountSetup(ctx, from)
 		if err != nil {
 			logFatal(err)
 		}
@@ -64,5 +64,5 @@ var iFILTransferCmd = &cobra.Command{
 
 func init() {
 	iFILCmd.AddCommand(iFILTransferCmd)
-	iFILTransferCmd.Flags().String("from", "", "address of the owner or operator of the agent")
+	iFILTransferCmd.Flags().String("from", "default", "account to transfer iFIL from")
 }

--- a/cmd/infpool_deposit_fil.go
+++ b/cmd/infpool_deposit_fil.go
@@ -19,7 +19,7 @@ var depositFILCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		from := cmd.Flag("from").Value.String()
-		_, auth, senderAccount, _, err := commonOwnerOrOperatorSetup(ctx, from)
+		auth, senderAccount, err := commonGenericAccountSetup(ctx, from)
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/infpool_deposit_fil.go
+++ b/cmd/infpool_deposit_fil.go
@@ -64,5 +64,5 @@ var depositFILCmd = &cobra.Command{
 
 func init() {
 	infinitypoolCmd.AddCommand(depositFILCmd)
-	depositFILCmd.Flags().String("from", "", "address of the owner or operator of the agent")
+	depositFILCmd.Flags().String("from", "default", "address of the owner or operator of the agent")
 }

--- a/cmd/infpool_exit_reserve.go
+++ b/cmd/infpool_exit_reserve.go
@@ -5,9 +5,11 @@ package cmd
 
 import (
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/glifio/go-pools/util"
 	"github.com/spf13/cobra"
 )
 
@@ -22,15 +24,43 @@ var exitReserveCmd = &cobra.Command{
 		s.Start()
 		defer s.Stop()
 
-		reserve, err := PoolsSDK.Query().InfPoolExitReserve(cmd.Context(), nil)
+		reserveBal, reserveMax, err := PoolsSDK.Query().InfPoolExitReserve(cmd.Context(), nil)
 		if err != nil {
 			logFatalf("Failed to get exit reserve %s", err)
 		}
 
 		s.Stop()
 
-		fmt.Printf("Total available liquidity in the Pool is %.08f FIL\n", reserve)
+		reserveBalFIL := util.ToFIL(reserveBal)
+
+		if reserveBal.Cmp(reserveMax) == 0 {
+			fmt.Printf("The exit reserve in the Pool is full at %.08f FIL\n", reserveBalFIL)
+		} else {
+			fmt.Printf("The exit reserve in the Pool is not full - it has %.08f FIL\n", reserveBalFIL)
+			// get the deficit
+			deficit := util.ToFIL(new(big.Int).Sub(reserveMax, reserveBal))
+			// div out the wads from the big ints
+			reserveBal.Div(reserveBal, big.NewInt(1e18))
+			reserveMax.Div(reserveMax, big.NewInt(1e18))
+			reservePerc := computePercentage(reserveBal, reserveMax)
+
+			fmt.Printf("The exit reserve is %.2f%% full, it needs %.08f FIL to be full\n", reservePerc, deficit)
+		}
 	},
+}
+
+// computePercentage computes (numerator/denominator) * 100
+func computePercentage(numerator, denominator *big.Int) float64 {
+	// Convert big.Int to big.Rat
+	rNumerator := new(big.Rat).SetInt(numerator)
+	rDenominator := new(big.Rat).SetInt(denominator)
+
+	// Compute the ratio
+	ratio := new(big.Rat).Quo(rNumerator, rDenominator)
+
+	percentageFloat := float64(ratio.Num().Int64()) / float64(ratio.Denom().Int64()) * 100
+
+	return percentageFloat
 }
 
 func init() {

--- a/cmd/infpool_redeem.go
+++ b/cmd/infpool_redeem.go
@@ -20,7 +20,7 @@ var redeemFILCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		from := cmd.Flag("from").Value.String()
-		_, auth, senderAccount, _, err := commonOwnerOrOperatorSetup(ctx, from)
+		auth, senderAccount, err := commonGenericAccountSetup(ctx, from)
 		if err != nil {
 			logFatal(err)
 		}
@@ -68,5 +68,5 @@ var redeemFILCmd = &cobra.Command{
 
 func init() {
 	infinitypoolCmd.AddCommand(redeemFILCmd)
-	redeemFILCmd.Flags().String("from", "", "address of the owner or operator of the agent")
+	redeemFILCmd.Flags().String("from", "", "account to send transaction")
 }

--- a/cmd/infpool_redeem.go
+++ b/cmd/infpool_redeem.go
@@ -30,7 +30,7 @@ var redeemFILCmd = &cobra.Command{
 			logFatal(err)
 		}
 
-		receiver, err := ParseAddressToEVM(cmd.Context(), args[1])
+		receiver, err := AddressOrAccountNameToEVM(cmd.Context(), args[1])
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/infpool_withdraw.go
+++ b/cmd/infpool_withdraw.go
@@ -20,7 +20,7 @@ var withdrawFILCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		from := cmd.Flag("from").Value.String()
-		_, auth, senderAccount, _, err := commonOwnerOrOperatorSetup(ctx, from)
+		auth, senderAccount, err := commonGenericAccountSetup(ctx, from)
 		if err != nil {
 			logFatal(err)
 		}
@@ -68,5 +68,5 @@ var withdrawFILCmd = &cobra.Command{
 
 func init() {
 	infinitypoolCmd.AddCommand(withdrawFILCmd)
-	withdrawFILCmd.Flags().String("from", "", "address of the owner or operator of the agent")
+	withdrawFILCmd.Flags().String("from", "default", "account to send transaction from")
 }

--- a/cmd/infpool_withdraw.go
+++ b/cmd/infpool_withdraw.go
@@ -30,7 +30,7 @@ var withdrawFILCmd = &cobra.Command{
 			logFatal(err)
 		}
 
-		receiver, err := ParseAddressToEVM(cmd.Context(), args[1])
+		receiver, err := AddressOrAccountNameToEVM(cmd.Context(), args[1])
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -135,7 +135,9 @@ func initConfig() {
 	viper.WatchConfig()
 
 	if slices.Contains(os.Args[1:], "wallet") &&
-		(slices.Contains(os.Args[1:], "new") || slices.Contains(os.Args[1:], "migrate")) {
+		(slices.Contains(os.Args[1:], "create-agent-accounts") ||
+			slices.Contains(os.Args[1:], "create-account") ||
+			slices.Contains(os.Args[1:], "migrate")) {
 		// Skip migration check
 	} else {
 		err = checkWalletMigrated()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,6 +114,10 @@ func initConfig() {
 		logFatal(err)
 	}
 
+	if err := util.NewAccountsStore(fmt.Sprintf("%s/accounts.toml", cfgDir)); err != nil {
+		logFatal(err)
+	}
+
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -85,7 +85,7 @@ func ParseAddressToNative(ctx context.Context, addr string) (address.Address, er
 	return filAddr, nil
 }
 
-func ParseAddressToEVM(ctx context.Context, addr string) (common.Address, error) {
+func AddressOrAccountNameToEVM(ctx context.Context, addr string) (common.Address, error) {
 	if strings.HasPrefix(addr, "0x") {
 		return common.HexToAddress(addr), nil
 	}
@@ -436,7 +436,7 @@ func getAgentAddressWithFlags(cmd *cobra.Command) (common.Address, error) {
 		}
 	}
 
-	return ParseAddressToEVM(cmd.Context(), agentAddrStr)
+	return AddressOrAccountNameToEVM(cmd.Context(), agentAddrStr)
 }
 
 func getAgentID(cmd *cobra.Command) (*big.Int, error) {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -176,7 +176,7 @@ func parseAddress(ctx context.Context, addr string, lapi lotusapi.FullNode) (com
 }
 
 func commonSetupOwnerCall() (agentAddr common.Address, auth *bind.TransactOpts, ownerAccount accounts.Account, requesterKey *ecdsa.PrivateKey, err error) {
-	as := util.AgentStore()
+	as := util.AccountsStore()
 
 	ownerAddr, _, err := as.GetAddrs(util.OwnerKey)
 	if err != nil {
@@ -192,7 +192,8 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 		return common.Address{}, nil, accounts.Account{}, nil, err
 	}
 
-	as := util.AgentStore()
+	as := util.AccountsStore()
+	agentStore := util.AgentStore()
 	ks := util.KeyStore()
 	backends := []accounts.Backend{}
 	backends = append(backends, ks)
@@ -212,7 +213,7 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 	// if no flag was passed, we just use the operator address by default
 	switch from {
 	case "", opEvm.String(), opFevm.String():
-		funded, err := as.IsFunded(ctx, PoolsSDK, opFevm, util.OperatorKeyFunded, opEvm.String())
+		funded, err := agentStore.IsFunded(ctx, PoolsSDK, opFevm, util.OperatorKeyFunded, opEvm.String())
 		if err != nil {
 			return common.Address{}, nil, accounts.Account{}, nil, err
 		}
@@ -279,7 +280,7 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 	return agentAddr, auth, account, requesterKey, nil
 }
 
-func getRequesterKey(as *util.AgentStorage, ks *keystore.KeyStore) (*ecdsa.PrivateKey, error) {
+func getRequesterKey(as *util.AccountsStorage, ks *keystore.KeyStore) (*ecdsa.PrivateKey, error) {
 	requesterAddr, _, err := as.GetAddrs(util.RequestKey)
 	if err != nil {
 		return nil, err
@@ -401,7 +402,7 @@ func AddressesToStrings(addrs []address.Address) []string {
 }
 
 func checkWalletMigrated() error {
-	as := util.AgentStore()
+	as := util.AccountsStore()
 	ksLegacy := util.KeyStoreLegacy()
 
 	notMigratedError := fmt.Errorf("wallet not migrated to encrypted keystore. Please run \"glif wallet migrate\"")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -455,7 +455,6 @@ func checkUnencryptedPrivateKeys() error {
 }
 
 func isFunded(ctx context.Context, caller address.Address) (bool, error) {
-	fmt.Println("Jim isFunded", caller)
 	lapi, closer, err := PoolsSDK.Extern().ConnectLotusClient()
 	if err != nil {
 		return false, err

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -211,7 +211,7 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 	var fromAddress common.Address
 	// if no flag was passed, we just use the operator address by default
 	switch from {
-	case "", opEvm.String(), opFevm.String():
+	case "", opEvm.String(), opFevm.String(), string(util.OperatorKey):
 		funded, err := isFunded(ctx, opFevm)
 		if err != nil {
 			return common.Address{}, nil, accounts.Account{}, nil, err
@@ -225,7 +225,7 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 		if err != nil {
 			return common.Address{}, nil, accounts.Account{}, nil, err
 		}
-	case owEvm.String(), owFevm.String():
+	case owEvm.String(), owFevm.String(), string(util.OwnerKey):
 		fromAddress = owEvm
 	default:
 		return common.Address{}, nil, accounts.Account{}, nil, errors.New("invalid from address")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -193,7 +193,7 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 
 	opEvm, opFevm, err := as.GetAddrs(string(util.OperatorKey))
 	if err != nil {
-		if err.Error() == "not found" {
+		if err == util.ErrKeyNotFound {
 			return common.Address{}, nil, accounts.Account{}, nil, fmt.Errorf("agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
 		}
 		return common.Address{}, nil, accounts.Account{}, nil, err
@@ -201,7 +201,7 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 
 	owEvm, owFevm, err := as.GetAddrs(string(util.OwnerKey))
 	if err != nil {
-		if err.Error() == "not found" {
+		if err == util.ErrKeyNotFound {
 			return common.Address{}, nil, accounts.Account{}, nil, fmt.Errorf("agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
 		}
 		return common.Address{}, nil, accounts.Account{}, nil, err
@@ -414,10 +414,10 @@ func checkWalletMigrated() error {
 	for _, key := range keys {
 		_, _, err := as.GetAddrs(string(key))
 		if err != nil {
-			if err.Error() == "not found" {
+			if err == util.ErrKeyNotFound {
 				_, _, err := ksLegacy.GetAddrs(key)
 				if err != nil {
-					if err.Error() == "not found" {
+					if err == util.ErrKeyNotFound {
 						// Account not created yet
 						continue
 					}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -226,7 +226,7 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 	var fromAddress common.Address
 	// if no flag was passed, we just use the operator address by default
 	switch strings.ToLower(from) {
-	case "", opEvm.String(), opFevm.String(), string(util.OperatorKey):
+	case "", strings.ToLower(opEvm.String()), strings.ToLower(opFevm.String()), string(util.OperatorKey):
 		funded, err := isFunded(ctx, opFevm)
 		if err != nil {
 			return common.Address{}, nil, accounts.Account{}, nil, err
@@ -240,7 +240,7 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 		if err != nil {
 			return common.Address{}, nil, accounts.Account{}, nil, err
 		}
-	case owEvm.String(), owFevm.String(), string(util.OwnerKey):
+	case strings.ToLower(owEvm.String()), strings.ToLower(owFevm.String()), string(util.OwnerKey):
 		fromAddress = owEvm
 	default:
 		return common.Address{}, nil, accounts.Account{}, nil, errors.New("invalid from address")
@@ -310,7 +310,7 @@ func commonGenericAccountSetup(ctx context.Context, from string) (auth *bind.Tra
 	if strings.HasPrefix(from, "0x") {
 		fromAddress = common.HexToAddress(from)
 	} else {
-		fromAddress, _, err = as.GetAddrs(from)
+		fromAddress, _, err = as.GetAddrs(strings.ToLower(from))
 		if err != nil {
 			if err == util.ErrKeyNotFound {
 				return nil, accounts.Account{}, fmt.Errorf("account \"%s\" not found in wallet. Setup with: glif wallet create-account %s", from, from)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -404,7 +404,7 @@ func checkWalletMigrated() error {
 	as := util.AccountsStore()
 	ksLegacy := util.KeyStoreLegacy()
 
-	notMigratedError := fmt.Errorf("wallet not migrated to encrypted keystore. Please run \"glif wallet migrate\"")
+	notMigratedError := fmt.Errorf("wallet not migrated to encrypted keystore. Please run: glif wallet migrate")
 
 	keys := []util.KeyType{
 		util.OwnerKey,
@@ -423,7 +423,7 @@ func checkWalletMigrated() error {
 				return err
 			}
 			if util.IsZeroAddress(oldAddr) {
-				return fmt.Errorf("missing %s key in legacy keys.toml", string(key))
+				return fmt.Errorf("agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
 			}
 			return notMigratedError
 		}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -209,7 +209,7 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 
 	var fromAddress common.Address
 	// if no flag was passed, we just use the operator address by default
-	switch from {
+	switch strings.ToLower(from) {
 	case "", opEvm.String(), opFevm.String(), string(util.OperatorKey):
 		funded, err := isFunded(ctx, opFevm)
 		if err != nil {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -536,8 +536,5 @@ func isFunded(ctx context.Context, caller address.Address) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if bal.Cmp(big.NewInt(0)) > 0 {
-		return true, nil
-	}
-	return false, nil
+	return bal.Cmp(big.NewInt(0)) > 0, nil
 }

--- a/cmd/wallet_balance.go
+++ b/cmd/wallet_balance.go
@@ -102,7 +102,7 @@ var balCmd = &cobra.Command{
 	Use:   "balance",
 	Short: "Gets the balances associated with your owner and operator keys",
 	Run: func(cmd *cobra.Command, args []string) {
-		as := util.AgentStore()
+		as := util.AccountsStore()
 		ownerEvm, ownerFevm, err := as.GetAddrs(util.OwnerKey)
 		if err != nil {
 			logFatal(err)

--- a/cmd/wallet_balance.go
+++ b/cmd/wallet_balance.go
@@ -100,20 +100,20 @@ func logBal(key util.KeyType, bal *big.Float, fevmAddr address.Address, evmAddr 
 // newCmd represents the new command
 var balCmd = &cobra.Command{
 	Use:   "balance",
-	Short: "Gets the balances associated with your owner and operator keys",
+	Short: "Gets the balances associated with your accounts",
 	Run: func(cmd *cobra.Command, args []string) {
 		as := util.AccountsStore()
-		ownerEvm, ownerFevm, err := as.GetAddrs(util.OwnerKey)
+		ownerEvm, ownerFevm, err := as.GetAddrs(string(util.OwnerKey))
 		if err != nil {
 			logFatal(err)
 		}
 
-		operatorEvm, operatorFevm, err := as.GetAddrs(util.OperatorKey)
+		operatorEvm, operatorFevm, err := as.GetAddrs(string(util.OperatorKey))
 		if err != nil {
 			logFatal(err)
 		}
 
-		requestEvm, requestFevm, err := as.GetAddrs(util.RequestKey)
+		requestEvm, requestFevm, err := as.GetAddrs(string(util.RequestKey))
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/wallet_change_passphrase.go
+++ b/cmd/wallet_change_passphrase.go
@@ -36,6 +36,10 @@ func changePassphrase(addr common.Address) error {
 
 	account := accounts.Account{Address: addr}
 
+	if !ks.HasAddress(addr) {
+		logFatal("Address not found in keystore")
+	}
+
 	oldPassphrase := ""
 	err := ks.Unlock(account, "")
 	if err != nil {
@@ -51,6 +55,14 @@ func changePassphrase(addr common.Address) error {
 			Message: "New passphrase",
 		}
 		survey.AskOne(prompt, &newPassphrase)
+		var confirmPassphrase string
+		confirmPrompt := &survey.Password{
+			Message: "Confirm passphrase",
+		}
+		survey.AskOne(confirmPrompt, &confirmPassphrase)
+		if newPassphrase != confirmPassphrase {
+			logFatal("Aborting. Passphrase confirmation did not match.")
+		}
 	}
 
 	err = ks.Update(account, oldPassphrase, newPassphrase)

--- a/cmd/wallet_change_passphrase.go
+++ b/cmd/wallet_change_passphrase.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -15,12 +16,25 @@ import (
 )
 
 var changePassphraseCmd = &cobra.Command{
-	Use:   "change-passphrase <address>",
+	Use:   "change-passphrase <account or address>",
 	Short: "Change the passphrase for an encrypted key in the keystore",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		addr := common.HexToAddress(args[0])
-		err := changePassphrase(addr)
+		var addr common.Address
+		var err error
+		if strings.HasPrefix(args[0], "0x") {
+			addr = common.HexToAddress(args[0])
+		} else {
+			as := util.AccountsStore()
+			addr, _, err = as.GetAddrs(args[0])
+			if err != nil {
+				if err == util.ErrKeyNotFound {
+					logFatal("Account not found in wallet")
+				}
+				logFatal(err)
+			}
+		}
+		err = changePassphrase(addr)
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/wallet_create_account.go
+++ b/cmd/wallet_create_account.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -38,6 +39,11 @@ var createAccountCmd = &cobra.Command{
 			name == string(util.OperatorKey) ||
 			name == string(util.RequestKey) {
 			logFatalf("Account name %s reserved for agent, try: glif wallet create-agent-accounts", name)
+		}
+
+		re := regexp.MustCompile(`^[tf][0-9]`)
+		if strings.HasPrefix(name, "0x") || re.MatchString(name) {
+			logFatalf("Invalid name")
 		}
 
 		fmt.Println("Creating account:", name)

--- a/cmd/wallet_create_account.go
+++ b/cmd/wallet_create_account.go
@@ -34,6 +34,12 @@ var createAccountCmd = &cobra.Command{
 			logFatalf("Account %s already exists", name)
 		}
 
+		if name == string(util.OwnerKey) ||
+			name == string(util.OperatorKey) ||
+			name == string(util.RequestKey) {
+			logFatalf("Account name %s reserved for agent, try: glif wallet create-agent-accounts", name)
+		}
+
 		fmt.Println("Creating account:", name)
 
 		var passphrase string

--- a/cmd/wallet_create_account.go
+++ b/cmd/wallet_create_account.go
@@ -1,0 +1,76 @@
+/*
+Copyright © 2023 Glif LTD
+*/
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/glifio/cli/util"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// createAccountCmd represents the create-account command
+var createAccountCmd = &cobra.Command{
+	Use:   "create-account [account-name]",
+	Short: "Create a single named account",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		as := util.AccountsStore()
+
+		var name string
+		if len(args) == 1 {
+			name = args[0]
+		} else {
+			name = "default"
+		}
+
+		_, err := as.Get(name)
+		if err != util.ErrKeyNotFound {
+			logFatalf("Account %s already exists", name)
+		}
+
+		fmt.Println("Creating account:", name)
+
+		var passphrase string
+		prompt := &survey.Password{
+			Message: "Please type a passphrase to encrypt your private key",
+		}
+		survey.AskOne(prompt, &passphrase)
+		var confirmPassphrase string
+		confirmPrompt := &survey.Password{
+			Message: "Confirm passphrase",
+		}
+		survey.AskOne(confirmPrompt, &confirmPassphrase)
+		if passphrase != confirmPassphrase {
+			logFatal("Aborting. Passphrase confirmation did not match.")
+		}
+
+		ks := util.KeyStore()
+
+		account, err := ks.NewAccount(passphrase)
+		if err != nil {
+			logFatal(err)
+		}
+
+		as.Set(name, account.Address.String())
+
+		if err := viper.WriteConfig(); err != nil {
+			logFatal(err)
+		}
+
+		accountAddr, accountDelAddr, err := as.GetAddrs(name)
+		if err != nil {
+			logFatal(err)
+		}
+
+		log.Printf("%s address: %s (ETH), %s (FIL)\n", name, accountAddr, accountDelAddr)
+	},
+}
+
+func init() {
+	walletCmd.AddCommand(createAccountCmd)
+}

--- a/cmd/wallet_create_account.go
+++ b/cmd/wallet_create_account.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"strings"
 
@@ -48,18 +49,20 @@ var createAccountCmd = &cobra.Command{
 
 		fmt.Println("Creating account:", name)
 
-		var passphrase string
-		prompt := &survey.Password{
-			Message: "Please type a passphrase to encrypt your private key",
-		}
-		survey.AskOne(prompt, &passphrase)
-		var confirmPassphrase string
-		confirmPrompt := &survey.Password{
-			Message: "Confirm passphrase",
-		}
-		survey.AskOne(confirmPrompt, &confirmPassphrase)
-		if passphrase != confirmPassphrase {
-			logFatal("Aborting. Passphrase confirmation did not match.")
+		passphrase, envSet := os.LookupEnv("GLIF_PASSPHRASE")
+		if !envSet {
+			prompt := &survey.Password{
+				Message: "Please type a passphrase to encrypt your private key",
+			}
+			survey.AskOne(prompt, &passphrase)
+			var confirmPassphrase string
+			confirmPrompt := &survey.Password{
+				Message: "Confirm passphrase",
+			}
+			survey.AskOne(confirmPrompt, &confirmPassphrase)
+			if passphrase != confirmPassphrase {
+				logFatal("Aborting. Passphrase confirmation did not match.")
+			}
 		}
 
 		ks := util.KeyStore()

--- a/cmd/wallet_create_account.go
+++ b/cmd/wallet_create_account.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/glifio/cli/util"
@@ -23,7 +24,7 @@ var createAccountCmd = &cobra.Command{
 
 		var name string
 		if len(args) == 1 {
-			name = args[0]
+			name = strings.ToLower(args[0])
 		} else {
 			name = "default"
 		}

--- a/cmd/wallet_create_agent_accounts.go
+++ b/cmd/wallet_create_agent_accounts.go
@@ -19,13 +19,13 @@ func panicIfKeyExists(key util.KeyType) {
 	if err == nil {
 		logFatal("owner account already created")
 	} else {
-		if err.Error() != "not found" {
+		if err != util.ErrKeyNotFound {
 			logFatal(err)
 		}
 	}
 }
 
-// createAgentAccountsCmd represents the new command
+// createAgentAccountsCmd represents the create-agent-accounts command
 var createAgentAccountsCmd = &cobra.Command{
 	Use:   "create-agent-accounts",
 	Short: "Create a set of accounts for an agent",

--- a/cmd/wallet_create_agent_accounts.go
+++ b/cmd/wallet_create_agent_accounts.go
@@ -24,11 +24,16 @@ func panicIfKeyExists(key util.KeyType, addr common.Address, err error) {
 	}
 }
 
-// newCmd represents the new command
-var newCmd = &cobra.Command{
-	Use:   "new",
-	Short: "Create a set of keys",
-	Long:  `Creates an owner, an operator, and a requester key and stores the values in $HOME/.config/glif/keys.toml. Note that the owner and requester keys are only applicable to Agents, the operator key is the primary key for interacting with smart contracts.`,
+// createAgentAccountsCmd represents the new command
+var createAgentAccountsCmd = &cobra.Command{
+	Use:   "create-agent-accounts",
+	Short: "Create a set of accounts for an agent",
+	Long: `Create 3 new accounts and store them in the keystore. The following accounts will be created:
+	  "owner" - a privileged account with full admin permissions for an agent (passphrase protected)
+		"operator" - a sub-account with reduced permissions to perform routine transactions (eg. payments),
+		             passphrase protection is optional
+		"requestor" - used for requesting credentials from the "Agent Data Oracle" (no passphrase)
+	`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		as := util.AccountsStore()
@@ -49,6 +54,14 @@ var newCmd = &cobra.Command{
 				Message: "Please type a passphrase to encrypt your owner private key",
 			}
 			survey.AskOne(prompt, &ownerPassphrase)
+			var confirmPassphrase string
+			confirmPrompt := &survey.Password{
+				Message: "Confirm passphrase",
+			}
+			survey.AskOne(confirmPrompt, &confirmPassphrase)
+			if ownerPassphrase != confirmPassphrase {
+				logFatal("Aborting. Passphrase confirmation did not match.")
+			}
 		}
 		owner, err := ks.NewAccount(ownerPassphrase)
 		if err != nil {
@@ -96,5 +109,5 @@ var newCmd = &cobra.Command{
 }
 
 func init() {
-	walletCmd.AddCommand(newCmd)
+	walletCmd.AddCommand(createAgentAccountsCmd)
 }

--- a/cmd/wallet_forward_fil.go
+++ b/cmd/wallet_forward_fil.go
@@ -20,12 +20,12 @@ import (
 
 var forwardFIL = &cobra.Command{
 	Use:   "forward-fil <from> <to> <amount>",
-	Short: "Transfers balances from owner or operator wallet to another address through the FilForwarder smart contract",
+	Short: "Transfers balances from an account to another address through the FilForwarder smart contract",
 	Args:  cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		from := args[0]
-		_, auth, senderAccount, _, err := commonOwnerOrOperatorSetup(ctx, from)
+		auth, senderAccount, err := commonGenericAccountSetup(ctx, from)
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/wallet_list.go
+++ b/cmd/wallet_list.go
@@ -14,7 +14,7 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lists the addresses associated with your owner, operator, and requester keys",
 	Run: func(cmd *cobra.Command, args []string) {
-		as := util.AgentStore()
+		as := util.AccountsStore()
 		ownerEvm, ownerFevm, err := as.GetAddrs(util.OwnerKey)
 		if err != nil {
 			logFatal(err)

--- a/cmd/wallet_list.go
+++ b/cmd/wallet_list.go
@@ -12,20 +12,20 @@ import (
 
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Lists the addresses associated with your owner, operator, and requester keys",
+	Short: "Lists the addresses associated with your accounts",
 	Run: func(cmd *cobra.Command, args []string) {
 		as := util.AccountsStore()
-		ownerEvm, ownerFevm, err := as.GetAddrs(util.OwnerKey)
+		ownerEvm, ownerFevm, err := as.GetAddrs(string(util.OwnerKey))
 		if err != nil {
 			logFatal(err)
 		}
 
-		operatorEvm, operatorFevm, err := as.GetAddrs(util.OperatorKey)
+		operatorEvm, operatorFevm, err := as.GetAddrs(string(util.OperatorKey))
 		if err != nil {
 			logFatal(err)
 		}
 
-		requestEvm, requestFevm, err := as.GetAddrs(util.RequestKey)
+		requestEvm, requestFevm, err := as.GetAddrs(string(util.RequestKey))
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/wallet_migrate.go
+++ b/cmd/wallet_migrate.go
@@ -30,7 +30,7 @@ var migrateCmd = &cobra.Command{
 		fmt.Printf("Please set a new passphrase to encrypt the owner key:\n\n")
 
 		as := util.AccountsStore()
-		ownerAddr, _, err := as.GetAddrs(util.OwnerKey)
+		ownerAddr, _, err := as.GetAddrs(string(util.OwnerKey))
 		if err != nil {
 			logFatal(err)
 		}

--- a/cmd/wallet_migrate.go
+++ b/cmd/wallet_migrate.go
@@ -29,7 +29,7 @@ var migrateCmd = &cobra.Command{
 
 		fmt.Printf("Please set a new passphrase to encrypt the owner key:\n\n")
 
-		as := util.AgentStore()
+		as := util.AccountsStore()
 		ownerAddr, _, err := as.GetAddrs(util.OwnerKey)
 		if err != nil {
 			logFatal(err)
@@ -61,7 +61,7 @@ func migrateLegacyKeys() error {
 func migrateLegacyKey(key util.KeyType) error {
 	ksLegacy := util.KeyStoreLegacy()
 	ks := util.KeyStore()
-	as := util.AgentStore()
+	as := util.AccountsStore()
 
 	pkStr, err := ksLegacy.Get(string(key))
 	if err != nil {

--- a/cmd/wallet_new.go
+++ b/cmd/wallet_new.go
@@ -31,7 +31,7 @@ var newCmd = &cobra.Command{
 	Long:  `Creates an owner, an operator, and a requester key and stores the values in $HOME/.config/glif/keys.toml. Note that the owner and requester keys are only applicable to Agents, the operator key is the primary key for interacting with smart contracts.`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		as := util.AgentStore()
+		as := util.AccountsStore()
 		ks := util.KeyStore()
 
 		ownerAddr, _, err := as.GetAddrs(util.OwnerKey)

--- a/cmd/wfil_alllowance.go
+++ b/cmd/wfil_alllowance.go
@@ -18,12 +18,12 @@ var wFILAllowanceCmd = &cobra.Command{
 		spenderStr := args[1]
 		fmt.Printf("Checking wFIL allowance of spender %s on holder %s...\n", spenderStr, holderStr)
 
-		holder, err := ParseAddressToEVM(cmd.Context(), holderStr)
+		holder, err := AddressOrAccountNameToEVM(cmd.Context(), holderStr)
 		if err != nil {
 			logFatalf("Failed to parse address %s\n", err)
 		}
 
-		spender, err := ParseAddressToEVM(cmd.Context(), spenderStr)
+		spender, err := AddressOrAccountNameToEVM(cmd.Context(), spenderStr)
 		if err != nil {
 			logFatalf("Failed to parse address %s\n", err)
 		}

--- a/cmd/wfil_balanceof.go
+++ b/cmd/wfil_balanceof.go
@@ -16,7 +16,7 @@ var wFILBalanceOfCmd = &cobra.Command{
 		strAddr := args[0]
 		fmt.Printf("Checking wFIL balance of %s...\n", strAddr)
 
-		addr, err := ParseAddressToEVM(cmd.Context(), strAddr)
+		addr, err := AddressOrAccountNameToEVM(cmd.Context(), strAddr)
 		if err != nil {
 			logFatalf("Failed to parse address %s", err)
 		}

--- a/events/types.go
+++ b/events/types.go
@@ -95,3 +95,10 @@ type WalletFILForward struct {
 	To     string `json:"to,omitempty"`
 	Amount string `json:"amount,omitempty"`
 }
+
+type AgentAdmin struct {
+	evtCommon
+	Action          string `json:"action"`
+	AgentID         string `json:"agent_id"`
+	NewAdminAddress string `json:"new_admin_address,omitempty"`
+}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-state-types v0.11.1
 	github.com/filecoin-project/lotus v1.23.0
-	github.com/glifio/go-pools v0.0.0-20230823172549-09a7123a4851
+	github.com/glifio/go-pools v0.0.0-20230823225723-2e0e75681fe6
 	github.com/glifio/go-wallet-utils v0.0.0-20230719050429-ff6c4bc75533
 	github.com/golang/mock v1.6.0
 	github.com/ipfs/go-cid v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-state-types v0.11.1
 	github.com/filecoin-project/lotus v1.23.0
-	github.com/glifio/go-pools v0.0.0-20230823225723-2e0e75681fe6
+	github.com/glifio/go-pools v0.0.0-20230826190148-33b0353b4ddc
 	github.com/glifio/go-wallet-utils v0.0.0-20230719050429-ff6c4bc75533
 	github.com/golang/mock v1.6.0
 	github.com/ipfs/go-cid v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/glifio/cli
 
 go 1.19
 
-replace github.com/glifio/go-pools v0.0.0-20230811201821-eb1e0e95114d => ../go-pools
-
 replace github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 => github.com/glifio/go-secp256k1 v0.0.1
 
 require (
@@ -13,7 +11,7 @@ require (
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-state-types v0.11.1
 	github.com/filecoin-project/lotus v1.23.0
-	github.com/glifio/go-pools v0.0.0-20230826190148-33b0353b4ddc
+	github.com/glifio/go-pools v0.0.0-20230829035659-cf313239bb86
 	github.com/glifio/go-wallet-utils v0.0.0-20230719050429-ff6c4bc75533
 	github.com/golang/mock v1.6.0
 	github.com/ipfs/go-cid v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/gbrlsnchs/jwt/v3 v3.0.1/go.mod h1:AncDcjXz18xetI3A6STfXq2w+LuTx8pQ8bG
 github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
 github.com/glifio/go-pools v0.0.0-20230823172549-09a7123a4851 h1:NGUcg9hS1f+8qM/PNrMTzlXmqD2WqR8OE6fLrB4gBDY=
 github.com/glifio/go-pools v0.0.0-20230823172549-09a7123a4851/go.mod h1:VSgu3BjwEmjUcBVk65kGS1+HrURNRqVGErjbhv4Mm7Q=
+github.com/glifio/go-pools v0.0.0-20230823225723-2e0e75681fe6 h1:v7BSI6f93RrVH2Hh4fb2P+DHmQplupdYPx/cXL4mYFQ=
+github.com/glifio/go-pools v0.0.0-20230823225723-2e0e75681fe6/go.mod h1:VSgu3BjwEmjUcBVk65kGS1+HrURNRqVGErjbhv4Mm7Q=
 github.com/glifio/go-secp256k1 v0.0.1 h1:BzsnpEtMl8RQtuJSfYDYK43MbTdVPtAQePZHn7TgSJk=
 github.com/glifio/go-secp256k1 v0.0.1/go.mod h1:AuM499x3qhpTvNyjqfLBkeYlEYQxD0ZB7YsYliALcPs=
 github.com/glifio/go-wallet-utils v0.0.0-20230719050429-ff6c4bc75533 h1:teuqQtVb7YMyqIOg+xUNO21qZAnm8ibhpKy4lIUBpag=

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqG
 github.com/gbrlsnchs/jwt/v3 v3.0.1 h1:lbUmgAKpxnClrKloyIwpxm4OuWeDl5wLk52G91ODPw4=
 github.com/gbrlsnchs/jwt/v3 v3.0.1/go.mod h1:AncDcjXz18xetI3A6STfXq2w+LuTx8pQ8bGEwRN8zVM=
 github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
-github.com/glifio/go-pools v0.0.0-20230826190148-33b0353b4ddc h1:fy4OvmJNnz67kz4cFBMHgIGDSG2499n/+NvmfZCAlj8=
-github.com/glifio/go-pools v0.0.0-20230826190148-33b0353b4ddc/go.mod h1:VSgu3BjwEmjUcBVk65kGS1+HrURNRqVGErjbhv4Mm7Q=
+github.com/glifio/go-pools v0.0.0-20230829035659-cf313239bb86 h1:J9NuATrZ3Vf3xf+pz5irrGYLFbPCtHXLsMXVBcHmEiE=
+github.com/glifio/go-pools v0.0.0-20230829035659-cf313239bb86/go.mod h1:VSgu3BjwEmjUcBVk65kGS1+HrURNRqVGErjbhv4Mm7Q=
 github.com/glifio/go-secp256k1 v0.0.1 h1:BzsnpEtMl8RQtuJSfYDYK43MbTdVPtAQePZHn7TgSJk=
 github.com/glifio/go-secp256k1 v0.0.1/go.mod h1:AuM499x3qhpTvNyjqfLBkeYlEYQxD0ZB7YsYliALcPs=
 github.com/glifio/go-wallet-utils v0.0.0-20230719050429-ff6c4bc75533 h1:teuqQtVb7YMyqIOg+xUNO21qZAnm8ibhpKy4lIUBpag=

--- a/go.sum
+++ b/go.sum
@@ -231,10 +231,8 @@ github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqG
 github.com/gbrlsnchs/jwt/v3 v3.0.1 h1:lbUmgAKpxnClrKloyIwpxm4OuWeDl5wLk52G91ODPw4=
 github.com/gbrlsnchs/jwt/v3 v3.0.1/go.mod h1:AncDcjXz18xetI3A6STfXq2w+LuTx8pQ8bGEwRN8zVM=
 github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
-github.com/glifio/go-pools v0.0.0-20230823172549-09a7123a4851 h1:NGUcg9hS1f+8qM/PNrMTzlXmqD2WqR8OE6fLrB4gBDY=
-github.com/glifio/go-pools v0.0.0-20230823172549-09a7123a4851/go.mod h1:VSgu3BjwEmjUcBVk65kGS1+HrURNRqVGErjbhv4Mm7Q=
-github.com/glifio/go-pools v0.0.0-20230823225723-2e0e75681fe6 h1:v7BSI6f93RrVH2Hh4fb2P+DHmQplupdYPx/cXL4mYFQ=
-github.com/glifio/go-pools v0.0.0-20230823225723-2e0e75681fe6/go.mod h1:VSgu3BjwEmjUcBVk65kGS1+HrURNRqVGErjbhv4Mm7Q=
+github.com/glifio/go-pools v0.0.0-20230826190148-33b0353b4ddc h1:fy4OvmJNnz67kz4cFBMHgIGDSG2499n/+NvmfZCAlj8=
+github.com/glifio/go-pools v0.0.0-20230826190148-33b0353b4ddc/go.mod h1:VSgu3BjwEmjUcBVk65kGS1+HrURNRqVGErjbhv4Mm7Q=
 github.com/glifio/go-secp256k1 v0.0.1 h1:BzsnpEtMl8RQtuJSfYDYK43MbTdVPtAQePZHn7TgSJk=
 github.com/glifio/go-secp256k1 v0.0.1/go.mod h1:AuM499x3qhpTvNyjqfLBkeYlEYQxD0ZB7YsYliALcPs=
 github.com/glifio/go-wallet-utils v0.0.0-20230719050429-ff6c4bc75533 h1:teuqQtVb7YMyqIOg+xUNO21qZAnm8ibhpKy4lIUBpag=

--- a/util/accounts.go
+++ b/util/accounts.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/filecoin-project/go-address"
 )
@@ -28,8 +30,12 @@ func NewAccountsStore(filename string) error {
 	return nil
 }
 
-func (a *AccountsStorage) GetAddrs(key KeyType) (common.Address, address.Address, error) {
-	evmAddress := common.HexToAddress(a.data[string(key)])
+func (a *AccountsStorage) GetAddrs(key string) (common.Address, address.Address, error) {
+	addr, ok := a.data[key]
+	if !ok || addr == "" {
+		return common.Address{}, address.Address{}, fmt.Errorf("not found")
+	}
+	evmAddress := common.HexToAddress(addr)
 
 	delegated, err := DelegatedFromEthAddr(evmAddress)
 	if err != nil {

--- a/util/accounts.go
+++ b/util/accounts.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/filecoin-project/go-address"
+)
+
+type AccountsStorage struct {
+	*Storage
+}
+
+var accountsStore *AccountsStorage
+
+func AccountsStore() *AccountsStorage {
+	return accountsStore
+}
+
+func NewAccountsStore(filename string) error {
+	accountsDefault := map[string]string{}
+
+	s, err := NewStorage(filename, accountsDefault)
+	if err != nil {
+		return err
+	}
+
+	accountsStore = &AccountsStorage{s}
+
+	return nil
+}
+
+func (a *AccountsStorage) GetAddrs(key KeyType) (common.Address, address.Address, error) {
+	evmAddress := common.HexToAddress(a.data[string(key)])
+
+	delegated, err := DelegatedFromEthAddr(evmAddress)
+	if err != nil {
+		return evmAddress, address.Address{}, err
+	}
+
+	return evmAddress, delegated, nil
+}

--- a/util/accounts.go
+++ b/util/accounts.go
@@ -20,7 +20,7 @@ func AccountsStore() *AccountsStorage {
 func NewAccountsStore(filename string) error {
 	accountsDefault := map[string]string{}
 
-	s, err := NewStorage(filename, accountsDefault)
+	s, err := NewStorage(filename, accountsDefault, true)
 	if err != nil {
 		return err
 	}

--- a/util/accounts.go
+++ b/util/accounts.go
@@ -1,8 +1,6 @@
 package util
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/filecoin-project/go-address"
 )
@@ -33,7 +31,7 @@ func NewAccountsStore(filename string) error {
 func (a *AccountsStorage) GetAddrs(key string) (common.Address, address.Address, error) {
 	addr, ok := a.data[key]
 	if !ok || addr == "" {
-		return common.Address{}, address.Address{}, fmt.Errorf("not found")
+		return common.Address{}, address.Address{}, ErrKeyNotFound
 	}
 	evmAddress := common.HexToAddress(addr)
 

--- a/util/agentstore.go
+++ b/util/agentstore.go
@@ -17,7 +17,7 @@ func NewAgentStore(filename string) error {
 		"tx":      "",
 	}
 
-	s, err := NewStorage(filename, agentDefault)
+	s, err := NewStorage(filename, agentDefault, true)
 	if err != nil {
 		return err
 	}

--- a/util/agentstore.go
+++ b/util/agentstore.go
@@ -1,15 +1,5 @@
 package util
 
-import (
-	"context"
-	"fmt"
-	"math/big"
-	"strconv"
-
-	"github.com/filecoin-project/go-address"
-	"github.com/glifio/go-pools/types"
-)
-
 type AgentStorage struct {
 	*Storage
 }
@@ -35,45 +25,4 @@ func NewAgentStore(filename string) error {
 	agentStore = &AgentStorage{s}
 
 	return nil
-}
-
-func (a *AgentStorage) IsFunded(ctx context.Context, psdk types.PoolsSDK, caller address.Address, keytype KeyType, key string) (bool, error) {
-	switch keytype {
-	case OperatorKeyFunded, OwnerKeyFunded:
-		f, ok := a.data[mapkey(keytype, key)]
-		if !ok {
-			lapi, closer, err := psdk.Extern().ConnectLotusClient()
-			if err != nil {
-				return false, err
-			}
-			defer closer()
-
-			bal, err := lapi.WalletBalance(ctx, caller)
-			if err != nil {
-				return false, err
-			}
-			if bal.Cmp(big.NewInt(0)) > 0 {
-				a.SetFunded(keytype, key, true)
-				return true, nil
-			}
-			return false, nil
-		}
-
-		return strconv.ParseBool(f)
-	default:
-		return false, fmt.Errorf("not supported key type for funded operation")
-	}
-}
-
-func (a *AgentStorage) SetFunded(keytype KeyType, key string, funded bool) error {
-	switch keytype {
-	case OperatorKeyFunded, OwnerKeyFunded:
-		return a.Set(mapkey(keytype, key), strconv.FormatBool(funded))
-	default:
-		return fmt.Errorf("not supported key type for funded operation")
-	}
-}
-
-func mapkey(keytype KeyType, key string) string {
-	return fmt.Sprintf("%s-%s", string(keytype), key)
 }

--- a/util/agentstore.go
+++ b/util/agentstore.go
@@ -6,20 +6,8 @@ import (
 	"math/big"
 	"strconv"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/glifio/go-pools/types"
-)
-
-type KeyType string
-
-const (
-	OwnerKey          KeyType = "owner"
-	OperatorKey       KeyType = "operator"
-	RequestKey        KeyType = "request"
-	OperatorKeyFunded KeyType = "opkeyf"
-	OwnerKeyFunded    KeyType = "ownkeyf"
 )
 
 type AgentStorage struct {
@@ -34,11 +22,9 @@ func AgentStore() *AgentStorage {
 
 func NewAgentStore(filename string) error {
 	agentDefault := map[string]string{
-		"id":                "",
-		"address":           "",
-		"tx":                "",
-		string(OwnerKey):    "",
-		string(OperatorKey): "",
+		"id":      "",
+		"address": "",
+		"tx":      "",
 	}
 
 	s, err := NewStorage(filename, agentDefault)
@@ -90,24 +76,4 @@ func (a *AgentStorage) SetFunded(keytype KeyType, key string, funded bool) error
 
 func mapkey(keytype KeyType, key string) string {
 	return fmt.Sprintf("%s-%s", string(keytype), key)
-}
-
-func (a *AgentStorage) GetAddrs(key KeyType) (common.Address, address.Address, error) {
-	evmAddress := common.HexToAddress(a.data[string(key)])
-
-	delegated, err := DelegatedFromEthAddr(evmAddress)
-	if err != nil {
-		return evmAddress, address.Address{}, err
-	}
-
-	return evmAddress, delegated, nil
-}
-
-func DelegatedFromEthAddr(addr common.Address) (address.Address, error) {
-	fevmAddr, err := ethtypes.ParseEthAddress(addr.String())
-	if err != nil {
-		return address.Address{}, err
-	}
-
-	return fevmAddr.ToFilecoinAddress()
 }

--- a/util/keys.go
+++ b/util/keys.go
@@ -15,11 +15,9 @@ import (
 type KeyType string
 
 const (
-	OwnerKey          KeyType = "owner"
-	OperatorKey       KeyType = "operator"
-	RequestKey        KeyType = "request"
-	OperatorKeyFunded KeyType = "opkeyf"
-	OwnerKeyFunded    KeyType = "ownkeyf"
+	OwnerKey    KeyType = "owner"
+	OperatorKey KeyType = "operator"
+	RequestKey  KeyType = "request"
 )
 
 func DeriveAddrFromPkString(pk string) (common.Address, address.Address, error) {

--- a/util/keys.go
+++ b/util/keys.go
@@ -12,6 +12,16 @@ import (
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 )
 
+type KeyType string
+
+const (
+	OwnerKey          KeyType = "owner"
+	OperatorKey       KeyType = "operator"
+	RequestKey        KeyType = "request"
+	OperatorKeyFunded KeyType = "opkeyf"
+	OwnerKeyFunded    KeyType = "ownkeyf"
+)
+
 func DeriveAddrFromPkString(pk string) (common.Address, address.Address, error) {
 	pkECDSA, err := crypto.HexToECDSA(pk)
 	if err != nil {
@@ -91,4 +101,13 @@ func TruncateAddr(addr string) string {
 	firstSix := addr[:6]
 	lastFour := addr[len(addr)-4:]
 	return fmt.Sprintf("%s...%s", firstSix, lastFour)
+}
+
+func DelegatedFromEthAddr(addr common.Address) (address.Address, error) {
+	fevmAddr, err := ethtypes.ParseEthAddress(addr.String())
+	if err != nil {
+		return address.Address{}, err
+	}
+
+	return fevmAddr.ToFilecoinAddress()
 }

--- a/util/keystore_legacy.go
+++ b/util/keystore_legacy.go
@@ -27,7 +27,7 @@ func NewKeyStoreLegacy(filename string) error {
 		string(RequestKey):  "",
 	}
 
-	s, err := NewStorage(filename, keyDefault)
+	s, err := NewStorage(filename, keyDefault, false)
 	if err != nil {
 		return err
 	}

--- a/util/keystore_legacy.go
+++ b/util/keystore_legacy.go
@@ -54,11 +54,11 @@ func (s *KeyStorageLegacy) GetPrivate(key KeyType) (*ecdsa.PrivateKey, error) {
 func (s *KeyStorageLegacy) GetAddrs(key KeyType) (common.Address, address.Address, error) {
 	pk, ok := s.data[string(key)]
 	if !ok {
-		return common.Address{}, address.Address{}, nil
+		return common.Address{}, address.Address{}, fmt.Errorf("not found")
 	}
 
 	if pk == "" {
-		return common.Address{}, address.Address{}, nil
+		return common.Address{}, address.Address{}, fmt.Errorf("not found")
 	}
 
 	pkECDSA, err := crypto.HexToECDSA(pk)

--- a/util/keystore_legacy.go
+++ b/util/keystore_legacy.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"crypto/ecdsa"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -40,7 +39,7 @@ func NewKeyStoreLegacy(filename string) error {
 func (s *KeyStorageLegacy) GetPrivate(key KeyType) (*ecdsa.PrivateKey, error) {
 	pk, ok := s.data[string(key)]
 	if !ok {
-		return nil, fmt.Errorf("key not found: %s", key)
+		return nil, ErrKeyNotFound
 	}
 
 	pkECDSA, err := crypto.HexToECDSA(pk)
@@ -54,11 +53,11 @@ func (s *KeyStorageLegacy) GetPrivate(key KeyType) (*ecdsa.PrivateKey, error) {
 func (s *KeyStorageLegacy) GetAddrs(key KeyType) (common.Address, address.Address, error) {
 	pk, ok := s.data[string(key)]
 	if !ok {
-		return common.Address{}, address.Address{}, fmt.Errorf("not found")
+		return common.Address{}, address.Address{}, ErrKeyNotFound
 	}
 
 	if pk == "" {
-		return common.Address{}, address.Address{}, fmt.Errorf("not found")
+		return common.Address{}, address.Address{}, ErrKeyNotFound
 	}
 
 	pkECDSA, err := crypto.HexToECDSA(pk)

--- a/util/storage.go
+++ b/util/storage.go
@@ -17,13 +17,15 @@ type StorageData map[string]string
 type Storage struct {
 	filename string
 	data     StorageData
+	writable bool
 }
 
 // NewStorage creates a new Storage instance and initializes it with the given filename.
-func NewStorage(filename string, defaultMap map[string]string) (*Storage, error) {
+func NewStorage(filename string, defaultMap map[string]string, writable bool) (*Storage, error) {
 	s := &Storage{
 		filename: filename,
 		data:     defaultMap,
+		writable: writable,
 	}
 
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
@@ -74,6 +76,9 @@ func (s *Storage) load() error {
 
 // save writes the current key-value pairs in the data map to the file.
 func (s *Storage) save() error {
+	if !s.writable {
+		return nil
+	}
 	keyStore, err := toml.Marshal(s.data)
 	if err != nil {
 		return err

--- a/util/storage.go
+++ b/util/storage.go
@@ -115,3 +115,15 @@ func (s *Storage) Delete(key string) error {
 	delete(s.data, key)
 	return s.save()
 }
+
+// AccountNames retrieves a list of all the account names
+func (s *Storage) AccountNames() []string {
+	keys := make([]string, len(s.data))
+
+	i := 0
+	for k := range s.data {
+		keys[i] = k
+		i++
+	}
+	return keys
+}

--- a/util/storage_test.go
+++ b/util/storage_test.go
@@ -15,7 +15,7 @@ var defaultMap = map[string]string{
 }
 
 func TestNewStorage(t *testing.T) {
-	_, err := util.NewStorage(testFilename, defaultMap)
+	_, err := util.NewStorage(testFilename, defaultMap, true)
 	if err != nil {
 		t.Errorf("NewStorage() error: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestNewStorage(t *testing.T) {
 }
 
 func TestSetNonExistentKey(t *testing.T) {
-	store, err := util.NewStorage(testFilename, defaultMap)
+	store, err := util.NewStorage(testFilename, defaultMap, true)
 	if err != nil {
 		t.Fatalf("NewStorage() error: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestSetNonExistentKey(t *testing.T) {
 }
 
 func TestGetSetDelete(t *testing.T) {
-	store, err := util.NewStorage(testFilename, defaultMap)
+	store, err := util.NewStorage(testFilename, defaultMap, true)
 	if err != nil {
 		t.Fatalf("NewStorage() error: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestGetSetDelete(t *testing.T) {
 }
 
 func TestNonexistentKey(t *testing.T) {
-	store, err := util.NewStorage(testFilename, defaultMap)
+	store, err := util.NewStorage(testFilename, defaultMap, true)
 	if err != nil {
 		t.Fatalf("NewStorage() error: %v", err)
 	}


### PR DESCRIPTION
@jimpick can you help me wrap this one up? Can we add a `--from` flag for `transfer-ownership` and `transfer-operator` so that the person can specify the new owner or operator? Also, can we make sure that we properly update the address cache with the new addresses (presumably only in agent.toml) 