### PR TITLE
Add prompts to nag user to make backups whenever the keystore is modified

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,6 +118,10 @@ func initConfig() {
 		logFatal(err)
 	}
 
+	if err := util.NewBackupsStore(fmt.Sprintf("%s/backups.toml", cfgDir)); err != nil {
+		logFatal(err)
+	}
+
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
@@ -148,6 +152,11 @@ func initConfig() {
 		err = checkUnencryptedPrivateKeys()
 		if err != nil {
 			log.Println(err)
+		}
+
+		err = confirmBackupExists()
+		if err != nil {
+			logFatal(err)
 		}
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -589,7 +589,7 @@ func confirmBackupExists() error {
 		bs.Set("confirmed-exists", "true")
 		v, _ := time.Now().UTC().MarshalText()
 		bs.Set("confirmed-at", string(v))
-		color.GreenString("Excellent!!!\n\n")
+		color.Green("Keys secured.\n\n")
 		return nil
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -598,7 +598,7 @@ func confirmBackupExists() error {
 	}
 
 	if choice == options[2] { // No, continue
-		color.Red("Continuing without backup. Dangerous!! Make sure you make a backup soon!\n\n")
+		color.Red("DANGER! Continuing without backup. Make a backup soon!\n\n")
 		return nil
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -11,12 +11,14 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/fatih/color"
 	"github.com/filecoin-project/go-address"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	"github.com/filecoin-project/go-state-types/manifest"
@@ -546,4 +548,75 @@ func isFunded(ctx context.Context, caller address.Address) (bool, error) {
 		return false, err
 	}
 	return bal.Cmp(big.NewInt(0)) > 0, nil
+}
+
+func confirmBackupExists() error {
+	backupExists := os.Getenv("GLIF_BACKUP_EXISTS")
+	if backupExists != "" {
+		return nil
+	}
+
+	as := util.AccountsStore()
+	if len(as.AccountNames()) == 0 {
+		return nil
+	}
+
+	bs := util.BackupsStore()
+	confirmedExists, err := bs.Get("confirmed-exists")
+	if err != nil {
+		return err
+	}
+
+	if confirmedExists == "true" {
+		return nil
+	}
+
+	options := []string{
+		"Yes, I made a backup",
+		"No, I did not make a backup, abort",
+		"No, I did not make a backup, continue anyways (dangerous!!!)",
+		"How do I make a backup?",
+	}
+
+	choice := ""
+	prompt := &survey.Select{
+		Message: fmt.Sprintf("The keystore has been updated, have you made a backup of %s ?", cfgDir),
+		Options: options,
+	}
+	survey.AskOne(prompt, &choice)
+
+	if choice == options[0] { // Yes, I made a backup
+		bs.Set("confirmed-exists", "true")
+		v, _ := time.Now().UTC().MarshalText()
+		bs.Set("confirmed-at", string(v))
+		color.GreenString("Excellent!!!\n\n")
+		return nil
+	}
+
+	if choice == options[1] { // No, abort
+		return fmt.Errorf("aborting")
+	}
+
+	if choice == options[2] { // No, continue
+		color.Red("Continuing without backup. Dangerous!! Make sure you make a backup soon!\n\n")
+		return nil
+	}
+
+	if choice == options[3] { // How do I make a backup?
+		fmt.Println("How to make a backup")
+		fmt.Println("====================")
+		fmt.Println()
+		fmt.Println("The configuration and keys are stored in the following directory:")
+		fmt.Println()
+		fmt.Printf("  %s\n\n", cfgDir)
+		fmt.Println("You can use a tool such as zip or tar to make an archive, and")
+		fmt.Println("then copy that file to a safe place. In the event of data loss,")
+		fmt.Println("you can use the backup to restore the files.")
+		fmt.Println()
+		fmt.Println("If you lose your keys and you don't have a backup, then you will")
+		fmt.Println("lose access to the funds in your agent and control of your miners!")
+		Exit(0)
+	}
+
+	return nil
 }

--- a/cmd/wallet_change_passphrase.go
+++ b/cmd/wallet_change_passphrase.go
@@ -83,6 +83,10 @@ func changePassphrase(addr common.Address) error {
 	if err != nil {
 		return err
 	}
+
+	bs := util.BackupsStore()
+	bs.Invalidate()
+
 	fmt.Println("Passphrase successfully changed.")
 
 	return nil

--- a/cmd/wallet_create_account.go
+++ b/cmd/wallet_create_account.go
@@ -83,6 +83,9 @@ var createAccountCmd = &cobra.Command{
 			logFatal(err)
 		}
 
+		bs := util.BackupsStore()
+		bs.Invalidate()
+
 		log.Printf("%s address: %s (ETH), %s (FIL)\n", name, accountAddr, accountDelAddr)
 	},
 }

--- a/cmd/wallet_create_agent_accounts.go
+++ b/cmd/wallet_create_agent_accounts.go
@@ -103,6 +103,9 @@ var createAgentAccountsCmd = &cobra.Command{
 		log.Printf("Request key: %s (ETH), %s (FIL)\n", requestAddr, requestDelAddr)
 		log.Println()
 		log.Println("Please make sure to fund your Owner Address with FIL before creating an Agent")
+
+		bs := util.BackupsStore()
+		bs.Invalidate()
 	},
 }
 

--- a/cmd/wallet_migrate.go
+++ b/cmd/wallet_migrate.go
@@ -41,6 +41,9 @@ var migrateCmd = &cobra.Command{
 
 		fmt.Printf("\nFor increased security, please delete the legacy %s/keys.toml file with the cleartext private keys.\n", cfgDir)
 		fmt.Println("The legacy keys.toml file is no longer needed, unless you are just testing and plan to downgrade.")
+
+		bs := util.BackupsStore()
+		bs.Invalidate()
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.3.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
-	github.com/fatih/color v1.13.0 // indirect
+	github.com/fatih/color v1.15.0 // indirect
 	github.com/filecoin-project/go-amt-ipld/v2 v2.1.1-0.20201006184820-924ee87a1349 // indirect
 	github.com/filecoin-project/go-amt-ipld/v3 v3.1.0 // indirect
 	github.com/filecoin-project/go-amt-ipld/v4 v4.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/ethereum/go-ethereum v1.12.0/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDB
 github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5 h1:BBso6MBKW8ncyZLv37o+KNyy0HrrHgfnOaGQC2qvN+A=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
+github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/filecoin-project/dagstore v0.5.2 h1:Nd6oXdnolbbVhpMpkYT5PJHOjQp4OBSntHpMV5pxj3c=
 github.com/filecoin-project/filecoin-ffi v0.30.4-0.20200910194244-f640612a1a1f h1:vg/6KEAOBjICMaWj+xofJCp09HYRfpO3ZbJsnJo22pA=
 github.com/filecoin-project/filecoin-ffi v0.30.4-0.20200910194244-f640612a1a1f/go.mod h1:+If3s2VxyjZn+KGGZIoRXBDSFQ9xL404JBJGf4WhEj0=

--- a/util/backups.go
+++ b/util/backups.go
@@ -1,0 +1,35 @@
+package util
+
+import "time"
+
+type BackupsStorage struct {
+	*Storage
+}
+
+var backupsStore *BackupsStorage
+
+func BackupsStore() *BackupsStorage {
+	return backupsStore
+}
+
+func NewBackupsStore(filename string) error {
+	backupsDefault := map[string]string{
+		"confirmed-exists": "false",
+		"modified-at":      "",
+	}
+
+	s, err := NewStorage(filename, backupsDefault, true)
+	if err != nil {
+		return err
+	}
+
+	backupsStore = &BackupsStorage{s}
+
+	return nil
+}
+
+func (a *BackupsStorage) Invalidate() {
+	v, _ := time.Now().UTC().MarshalText()
+	a.Set("modified-at", string(v))
+	a.Set("confirmed-exists", "false")
+}


### PR DESCRIPTION
The following prompt is presented:

```
? The keystore has been updated, have you made a backup of <cfgDir> ?  [Use arrows to move, type to filter]
> Yes, I made a backup
  No, I did not make a backup, abort
  No, I did not make a backup, continue anyways (dangerous!!!)
  How do I make a backup?
```

A new `backups.toml` file is used to record if user has claimed a backup exists. If so, the nag message won't appear on subsequent cli invocations.

If new accounts are created, or passphrases changed, the nag message will re-appear.

The GLIF_BACKUP_EXIST env var can be set to suppress the interactive prompt.