### PR TITLE
Change error handling for better error message on missing key

### DIFF
--- a/cmd/agent_admin_new_key.go
+++ b/cmd/agent_admin_new_key.go
@@ -7,6 +7,7 @@ Copyright © 2023 Glif LTD
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -54,7 +55,8 @@ var newRequestKeyCmd = &cobra.Command{
 		}
 
 		key, err := as.Get(keyName)
-		if err != util.ErrKeyNotFound {
+		var e *util.ErrKeyNotFound
+		if !errors.As(err, &e) {
 			// rename the existing key
 			newKeyName := fmt.Sprintf("%s-%s", keyName, time.Now().Format(time.RFC3339))
 			as.Set(newKeyName, key)

--- a/cmd/agent_create.go
+++ b/cmd/agent_create.go
@@ -4,6 +4,7 @@ Copyright © 2023 Glif LTD
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -32,8 +33,11 @@ var createCmd = &cobra.Command{
 
 		// Check if an agent already exists
 		addressStr, err := as.Get("address")
-		if err != nil && err != util.ErrKeyNotFound {
-			logFatal(err)
+		if err != nil {
+			var e *util.ErrKeyNotFound
+			if !errors.As(err, &e) {
+				logFatal(err)
+			}
 		}
 		if addressStr != "" {
 			logFatalf("Agent already exists: %s", addressStr)
@@ -119,7 +123,8 @@ var createCmd = &cobra.Command{
 
 func checkExists(err error) {
 	if err != nil {
-		if err == util.ErrKeyNotFound {
+		var e *util.ErrKeyNotFound
+		if errors.As(err, &e) {
 			logFatal("Agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
 		}
 		logFatal(err)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -220,7 +220,8 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 
 	opEvm, opFevm, err := as.GetAddrs(string(util.OperatorKey))
 	if err != nil {
-		if err == util.ErrKeyNotFound {
+		var e *util.ErrKeyNotFound
+		if errors.As(err, &e) {
 			return common.Address{}, nil, accounts.Account{}, nil, fmt.Errorf("agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
 		}
 		return common.Address{}, nil, accounts.Account{}, nil, err
@@ -228,7 +229,8 @@ func commonOwnerOrOperatorSetup(ctx context.Context, from string) (agentAddr com
 
 	owEvm, owFevm, err := as.GetAddrs(string(util.OwnerKey))
 	if err != nil {
-		if err == util.ErrKeyNotFound {
+		var e *util.ErrKeyNotFound
+		if errors.As(err, &e) {
 			return common.Address{}, nil, accounts.Account{}, nil, fmt.Errorf("agent accounts not found in wallet. Setup with: glif wallet create-agent-accounts")
 		}
 		return common.Address{}, nil, accounts.Account{}, nil, err
@@ -323,7 +325,8 @@ func commonGenericAccountSetup(ctx context.Context, from string) (auth *bind.Tra
 	} else {
 		fromAddress, _, err = as.GetAddrs(strings.ToLower(from))
 		if err != nil {
-			if err == util.ErrKeyNotFound {
+			var e *util.ErrKeyNotFound
+			if errors.As(err, &e) {
 				return nil, accounts.Account{}, fmt.Errorf("account \"%s\" not found in wallet. Setup with: glif wallet create-account %s", from, from)
 			}
 			return nil, accounts.Account{}, err
@@ -496,10 +499,12 @@ func checkWalletMigrated() error {
 	for _, key := range keys {
 		_, _, err := as.GetAddrs(string(key))
 		if err != nil {
-			if err == util.ErrKeyNotFound {
+			var e *util.ErrKeyNotFound
+			if errors.As(err, &e) {
 				_, _, err := ksLegacy.GetAddrs(key)
 				if err != nil {
-					if err == util.ErrKeyNotFound {
+					var e *util.ErrKeyNotFound
+					if errors.As(err, &e) {
 						// Account not created yet
 						continue
 					}

--- a/cmd/wallet_change_passphrase.go
+++ b/cmd/wallet_change_passphrase.go
@@ -4,6 +4,7 @@ Copyright © 2023 Glif LTD
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -28,7 +29,8 @@ var changePassphraseCmd = &cobra.Command{
 			as := util.AccountsStore()
 			addr, _, err = as.GetAddrs(args[0])
 			if err != nil {
-				if err == util.ErrKeyNotFound {
+				var e *util.ErrKeyNotFound
+				if errors.As(err, &e) {
 					logFatal("Account not found in wallet")
 				}
 				logFatal(err)

--- a/cmd/wallet_create_account.go
+++ b/cmd/wallet_create_account.go
@@ -4,6 +4,7 @@ Copyright © 2023 Glif LTD
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -32,7 +33,8 @@ var createAccountCmd = &cobra.Command{
 		}
 
 		_, err := as.Get(name)
-		if err != util.ErrKeyNotFound {
+		var e *util.ErrKeyNotFound
+		if !errors.As(err, &e) {
 			logFatalf("Account %s already exists", name)
 		}
 

--- a/cmd/wallet_create_agent_accounts.go
+++ b/cmd/wallet_create_agent_accounts.go
@@ -4,6 +4,7 @@ Copyright © 2023 Glif LTD
 package cmd
 
 import (
+	"errors"
 	"log"
 	"os"
 
@@ -19,7 +20,8 @@ func panicIfKeyExists(key util.KeyType) {
 	if err == nil {
 		logFatal("owner account already created")
 	} else {
-		if err != util.ErrKeyNotFound {
+		var e *util.ErrKeyNotFound
+		if !errors.As(err, &e) {
 			logFatal(err)
 		}
 	}

--- a/cmd/wallet_label_account.go
+++ b/cmd/wallet_label_account.go
@@ -4,6 +4,7 @@ Copyright © 2023 Glif LTD
 package cmd
 
 import (
+	"errors"
 	"log"
 
 	"github.com/glifio/cli/util"
@@ -25,7 +26,8 @@ var labelAccountCmd = &cobra.Command{
 		if err == nil {
 			logFatalf("%s account already created\n", name)
 		} else {
-			if err != util.ErrKeyNotFound {
+			var e *util.ErrKeyNotFound
+			if !errors.As(err, &e) {
 				logFatal(err)
 			}
 		}

--- a/cmd/wallet_list.go
+++ b/cmd/wallet_list.go
@@ -4,6 +4,7 @@ Copyright © 2023 Glif LTD
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/glifio/cli/util"
@@ -66,7 +67,8 @@ var listCmd = &cobra.Command{
 func printAddresses(as *util.AccountsStorage, name string) {
 	evm, fevm, err := as.GetAddrs(name)
 	if err != nil {
-		if err == util.ErrKeyNotFound {
+		var e *util.ErrKeyNotFound
+		if errors.As(err, &e) {
 			return
 		}
 		logFatal(err)

--- a/util/accounts.go
+++ b/util/accounts.go
@@ -31,7 +31,7 @@ func NewAccountsStore(filename string) error {
 func (a *AccountsStorage) GetAddrs(key string) (common.Address, address.Address, error) {
 	addr, ok := a.data[key]
 	if !ok || addr == "" {
-		return common.Address{}, address.Address{}, ErrKeyNotFound
+		return common.Address{}, address.Address{}, &ErrKeyNotFound{key}
 	}
 	evmAddress := common.HexToAddress(addr)
 

--- a/util/keystore_legacy.go
+++ b/util/keystore_legacy.go
@@ -39,7 +39,7 @@ func NewKeyStoreLegacy(filename string) error {
 func (s *KeyStorageLegacy) GetPrivate(key KeyType) (*ecdsa.PrivateKey, error) {
 	pk, ok := s.data[string(key)]
 	if !ok {
-		return nil, ErrKeyNotFound
+		return nil, &ErrKeyNotFound{string(key)}
 	}
 
 	pkECDSA, err := crypto.HexToECDSA(pk)
@@ -53,11 +53,11 @@ func (s *KeyStorageLegacy) GetPrivate(key KeyType) (*ecdsa.PrivateKey, error) {
 func (s *KeyStorageLegacy) GetAddrs(key KeyType) (common.Address, address.Address, error) {
 	pk, ok := s.data[string(key)]
 	if !ok {
-		return common.Address{}, address.Address{}, ErrKeyNotFound
+		return common.Address{}, address.Address{}, &ErrKeyNotFound{string(key)}
 	}
 
 	if pk == "" {
-		return common.Address{}, address.Address{}, ErrKeyNotFound
+		return common.Address{}, address.Address{}, &ErrKeyNotFound{string(key)}
 	}
 
 	pkECDSA, err := crypto.HexToECDSA(pk)

--- a/util/storage.go
+++ b/util/storage.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,7 +8,11 @@ import (
 	toml "github.com/pelletier/go-toml/v2"
 )
 
-var ErrKeyNotFound error = errors.New("key not found")
+type ErrKeyNotFound struct {
+	Key string
+}
+
+func (e *ErrKeyNotFound) Error() string { return "key not found: " + e.Key }
 
 type StorageData map[string]string
 
@@ -96,7 +99,7 @@ func (s *Storage) save() error {
 func (s *Storage) Get(key string) (string, error) {
 	value, ok := s.data[key]
 	if !ok {
-		return "", ErrKeyNotFound
+		return "", &ErrKeyNotFound{key}
 	}
 	return value, nil
 }
@@ -110,7 +113,7 @@ func (s *Storage) Set(key, value string) error {
 // Delete removes a key-value pair from the data map and saves the data to the file.
 func (s *Storage) Delete(key string) error {
 	if _, ok := s.data[key]; !ok {
-		return ErrKeyNotFound
+		return &ErrKeyNotFound{key}
 	}
 	delete(s.data, key)
 	return s.save()


### PR DESCRIPTION
Example error message:

```
./glif agent withdraw f01201327 200
? Owner key passphrase *******
2023/12/18 20:36:02 key not found: 200
```

This patch is quite massive and touches a lot of code related to migrating from the old config files, so it needs more testing before it's ready to merge.