### PR TITLE
Create .glif/config.toml with defaults if it doesn't exist

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -137,8 +137,10 @@ func initConfig() {
 		if errors.Is(err, fs.ErrNotExist) {
 			logFatalf("No config file found at %s\n", viper.ConfigFileUsed())
 		} else if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			// Config file not found; ignore error if desired
-			fmt.Fprintln(os.Stderr, "Warning: No config file found.")
+			// No .glif/config.toml, populate with mainnet defaults
+			viper.Set("daemon.rpc-url", deploy.Extern.LotusDialAddr)
+			viper.Set("daemon.token", "")
+			viper.SafeWriteConfig()
 		} else {
 			logFatalf("Config file error: %v\n", err)
 		}


### PR DESCRIPTION
This was pretty easy.

The README could be simplified and the Makefile / example config.toml files could be removed.