### PR TITLE
Date formatting for downgrades

### DIFF
--- a/cmd/plus_downgrade.go
+++ b/cmd/plus_downgrade.go
@@ -63,8 +63,10 @@ var plusDowngradeCmd = &cobra.Command{
 
 		if refundGlf.Sign() == 1 && windowEnd.After(time.Now()) {
 			fmt.Println("Attempting to downgrade early...")
-			fmt.Printf("Tier activation timestamp: %v\n", windowStart.UTC())
-			fmt.Printf("Free downgrade after %v (%d days, %d hours)\n", windowEnd.UTC(), days, hours)
+			windowStartFormatted := windowStart.UTC().Format("January 2 2006 15:04")
+			fmt.Printf("Tier activation timestamp: %v\n", windowStartFormatted)
+			windowEndFormatted := windowEnd.UTC().Format("January 2 2006 15:04")
+			fmt.Printf("Free downgrade after %v UTC (%d days, %d hours)\n", windowEndFormatted, days, hours)
 			penaltyAmount := new(big.Int).Div(
 				new(big.Int).Mul(refundGlf, penaltyFee),
 				big.NewInt(10000))

--- a/cmd/plus_info.go
+++ b/cmd/plus_info.go
@@ -42,9 +42,11 @@ var plusInfoCmd = &cobra.Command{
 		windowStart, windowEnd, days, hours := getTierSwitchWindow(info, penaltyWindow)
 
 		if info.Tier > 0 {
-			fmt.Printf("Tier activation timestamp: %v\n", windowStart.UTC())
+			windowStartFormatted := windowStart.UTC().Format("January 2 2006 15:04")
+			fmt.Printf("Tier activation timestamp: %v\n", windowStartFormatted)
 			if windowEnd.After(time.Now()) {
-				fmt.Printf("Free downgrade after %v (%d days, %d hours)\n", windowEnd.UTC(), days, hours)
+				windowEndFormatted := windowEnd.UTC().Format("January 2 2006 15:04")
+				fmt.Printf("Free downgrade after %v UTC (%d days, %d hours)\n", windowEndFormatted, days, hours)
 				penaltyBasis, _ := penaltyFee.Float64()
 				fmt.Printf("Early downgrade penalty fee: %.02f%%\n", penaltyBasis/100.00)
 			} else {


### PR DESCRIPTION
For #170

Example output:

```
$ ./glif plus info
GLIF Card Token ID: 7

Tier: Bronze
Locked Amount: 50000.000000000 GLF
Tier activation timestamp: September 11 2025 19:17
Free downgrade after October 11 2025 19:17 UTC (29 days, 20 hours)
Early downgrade penalty fee: 5.00%

Personal Cashback Percentage: 0.00%
Cashback earned: 0.000000000 FIL
Vault balance: 0.000000000 GLF
Base Conversion Rate: 1 FIL = 0.004000000 GLF
```